### PR TITLE
Improve GUI controls and fix read-only crash in odd-even plot

### DIFF
--- a/quicklook/app/app.py
+++ b/quicklook/app/app.py
@@ -571,6 +571,18 @@ def cancel(target):
     return jsonify({"ok": False, "reason": "not running"}), 400
 
 
+@app.route("/cancel-all", methods=["POST"])
+def cancel_all():
+    """Cancel all pending (queued or running) jobs."""
+    cancelled = []
+    for name, info in jobs.items():
+        if info["status"] in ("running", "queued"):
+            info["cancel_event"].set()
+            info["status"] = "cancelled"
+            cancelled.append(name)
+    return jsonify({"ok": True, "cancelled": cancelled})
+
+
 @app.route("/delete-output", methods=["POST"])
 def delete_output():
     """Delete an output PNG and its associated H5 file."""

--- a/quicklook/app/templates/index.html
+++ b/quicklook/app/templates/index.html
@@ -78,6 +78,39 @@
       display: inline-flex; align-items: center; justify-content: center;
       width: 16px; height: 16px; border-radius: 50%; font-size: 0.65rem; font-weight: 700;
       background: var(--border); color: var(--text-sec); cursor: help; flex-shrink: 0;
+      position: relative; user-select: none;
+    }
+    .help-tip:hover { background: var(--primary); color: #fff; }
+    .help-tip::after {
+      content: attr(data-tip);
+      position: absolute;
+      bottom: calc(100% + 6px); left: 50%;
+      transform: translateX(calc(-50% + var(--tip-shift, 0px)));
+      background: var(--text); color: var(--card-bg);
+      padding: 6px 10px; border-radius: 6px;
+      font-size: 0.75rem; font-weight: normal;
+      white-space: normal; width: max-content; max-width: 260px;
+      text-align: left; line-height: 1.4;
+      letter-spacing: normal; text-transform: none;
+      opacity: 0; visibility: hidden;
+      transition: opacity 0.15s, visibility 0.15s;
+      pointer-events: none; z-index: 100;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+    }
+    .help-tip::before {
+      content: ''; position: absolute;
+      bottom: calc(100% + 1px); left: 50%;
+      transform: translateX(-50%);
+      border: 5px solid transparent;
+      border-top-color: var(--text);
+      opacity: 0; visibility: hidden;
+      transition: opacity 0.15s, visibility 0.15s;
+      pointer-events: none; z-index: 100;
+    }
+    .help-tip:hover::after, .help-tip:hover::before,
+    .help-tip.active::after, .help-tip.active::before,
+    .help-tip:focus::after, .help-tip:focus::before {
+      opacity: 1; visibility: visible;
     }
     input[type="text"], input[type="number"], select, textarea {
       width: 100%; padding: 7px 10px; border: 1px solid var(--input-border); border-radius: 5px;
@@ -117,8 +150,21 @@
 
     /* --- Job queue --- */
     .queue-section { margin-bottom: 16px; }
-    .queue-section h2 { font-size: 1rem; margin-bottom: 8px; }
+    .queue-section h2 { font-size: 1rem; margin-bottom: 0; }
+    .queue-header {
+      display: flex; align-items: center; gap: 10px; margin-bottom: 8px; flex-wrap: wrap;
+    }
+    .queue-count { font-size: 0.78rem; color: var(--text-sec); font-weight: 500; }
+    .queue-toggle {
+      margin-left: auto; font-size: 0.8rem; color: var(--primary); cursor: pointer;
+      background: none; border: none; padding: 0; font-weight: 600;
+    }
+    .queue-toggle:hover { text-decoration: underline; }
     .queue-list { list-style: none; padding: 0; margin: 0; }
+    .queue-list.collapsed { display: none; }
+    .queue-hidden-hint {
+      font-size: 0.78rem; color: var(--text-sec); padding: 6px 12px; font-style: italic;
+    }
     .queue-item {
       display: flex; align-items: center; gap: 10px;
       padding: 8px 12px; background: var(--card-bg); border: 1px solid var(--border);
@@ -216,8 +262,10 @@
     /* --- Collapsible sections --- */
     .collapsible {
       background: var(--hover-bg); border: 1px solid var(--border); border-radius: 8px;
-      margin-bottom: 12px; overflow: hidden;
+      margin-bottom: 12px;
     }
+    .collapsible-header { border-radius: 8px; }
+    .collapsible.open .collapsible-header { border-radius: 8px 8px 0 0; }
     .collapsible-header {
       display: flex; align-items: center; justify-content: space-between; width: 100%;
       padding: 12px 16px; background: var(--card-bg); border: none; cursor: pointer;
@@ -288,7 +336,7 @@
         <div class="full-width">
           <div class="label-row">
             <label for="name">Target Name</label>
-            <span class="help-tip" title="TOI ID (e.g. TOI-1234), TIC ID (e.g. TIC 12345678), or common name (e.g. WASP-21)">?</span>
+            <span class="help-tip" tabindex="0" data-tip="TOI ID (e.g. TOI-1234), TIC ID (e.g. TIC 12345678), or common name (e.g. WASP-21).">?</span>
           </div>
           <input type="text" name="name" id="name" placeholder="e.g. TOI-1234, TIC 12345678" required autofocus>
           <div class="validation-msg" id="nameValidation">Enter a target name (TOI, TIC, or common name)</div>
@@ -296,23 +344,30 @@
         <div>
           <div class="label-row">
             <label for="sector">Sector</label>
-            <span class="help-tip" title="-1 = latest sector. Ignored when 'Each Sector' is checked.">?</span>
+            <span class="help-tip" tabindex="0" data-tip="-1 = latest available sector. Ignored when 'Run each available sector' is checked.">?</span>
           </div>
           <input type="number" name="sector" id="sector" value="-1">
           <label style="display:flex;align-items:center;gap:5px;margin-top:5px;font-weight:normal;font-size:0.82rem;cursor:pointer;">
             <input type="checkbox" name="each_sector" id="each_sector"> Run each available sector
+            <span class="help-tip" tabindex="0" data-tip="Submit one job per available sector for this target instead of just the selected one.">?</span>
           </label>
         </div>
         <div>
-          <label for="pipeline">Pipeline</label>
+          <div class="label-row">
+            <label for="pipeline">Pipeline</label>
+            <span class="help-tip" tabindex="0" data-tip="Source of TESS light curves. SPOC = official 2-min cadence; TESS-SPOC/QLP/TGLC/CDIPS/PATHOS/TASOC/T16 are HLSP products from FFIs.">?</span>
+          </div>
           <select name="pipeline" id="pipeline">
-            {% for p in ['spoc','tess-spoc','tasoc','cdips','pathos','qlp','tglc'] %}
+            {% for p in ['spoc','tess-spoc','tasoc','cdips','pathos','qlp','tglc','t16'] %}
             <option value="{{p}}">{{ p | upper }}</option>
             {% endfor %}
           </select>
         </div>
         <div>
-          <label for="fluxtype">Flux Type</label>
+          <div class="label-row">
+            <label for="fluxtype">Flux Type</label>
+            <span class="help-tip" tabindex="0" data-tip="PDCSAP = pre-search data conditioned flux, corrected for systematics (recommended). SAP = raw simple aperture photometry.">?</span>
+          </div>
           <select name="fluxtype" id="fluxtype">
             {% for f in ['pdcsap','sap'] %}
             <option value="{{f}}">{{ f | upper }}</option>
@@ -322,9 +377,14 @@
         <div>
           <div class="label-row">
             <label for="exptime">Exposure Time (s)</label>
-            <span class="help-tip" title="Cadence in seconds: 20 (20s), 120 (2min), 600 (10min), 1800 (30min). Leave blank for auto-detect.">?</span>
+            <span class="help-tip" tabindex="0" data-tip="Cadence in seconds: 20 (20s), 120 (2min), 200 (3.3min), 600 (10min), 1800 (30min). Select 'auto' to auto-detect.">?</span>
           </div>
-          <input type="number" name="exptime" id="exptime" placeholder="auto">
+          <select name="exptime" id="exptime">
+            <option value="" selected>auto</option>
+            {% for e in [20, 120, 200, 600, 1800] %}
+            <option value="{{e}}">{{e}}</option>
+            {% endfor %}
+          </select>
         </div>
       </div>
     </div>
@@ -339,7 +399,10 @@
     <div class="collapsible-content">
       <div class="form-grid">
         <div>
-          <label for="quality_bitmask">Quality Bitmask</label>
+          <div class="label-row">
+            <label for="quality_bitmask">Quality Bitmask</label>
+            <span class="help-tip" tabindex="0" data-tip="How aggressively to drop cadences flagged by SPOC quality flags. 'default' is recommended; 'hardest' rejects the most data.">?</span>
+          </div>
           <select name="quality_bitmask" id="quality_bitmask">
             {% for q in ['none','default','hard','hardest'] %}
             <option value="{{q}}" {% if q == 'default' %}selected{% endif %}>{{ q | capitalize }}</option>
@@ -347,38 +410,60 @@
           </select>
         </div>
         <div>
-          <label for="edge_cutoff">Edge Cutoff (days)</label>
+          <div class="label-row">
+            <label for="edge_cutoff">Edge Cutoff (days)</label>
+            <span class="help-tip" tabindex="0" data-tip="Days to trim from the start and end of each sector to remove edge artifacts and momentum-dump effects.">?</span>
+          </div>
           <input type="number" step="0.01" name="edge_cutoff" id="edge_cutoff" value="0.1">
         </div>
         <div class="full-width">
           <div class="label-row">
             <label for="sigma_clip_raw">Sigma Clip Raw (lo hi)</label>
-            <span class="help-tip" title="Two values: lower and upper sigma bounds for raw light curve clipping. E.g. '10 5' clips below 10-sigma and above 5-sigma.">?</span>
+            <span class="help-tip" tabindex="0" data-tip="Two values: lower and upper sigma bounds for raw light curve clipping. E.g. '10 5' clips below 10-sigma and above 5-sigma.">?</span>
           </div>
           <input type="text" name="sigma_clip_raw" id="sigma_clip_raw" placeholder="10 5" value="10 5">
         </div>
         <div>
-          <label for="flatten_method">Flatten Method</label>
-          <input type="text" name="flatten_method" id="flatten_method" value="biweight">
+          <div class="label-row">
+            <label for="flatten_method">Flatten Method</label>
+            <span class="help-tip" tabindex="0" data-tip="Detrending algorithm (wotan). 'biweight' is robust and fast; 'gp' uses Gaussian Processes; others are spline/filter variants.">?</span>
+          </div>
+          <select name="flatten_method" id="flatten_method">
+            <option value="biweight" selected>biweight</option>
+            <option value="gp">gp</option>
+            <option value="medfilt">medfilt</option>
+            <option value="median">median</option>
+            <option value="rspline">rspline</option>
+            <option value="hspline">hspline</option>
+            <option value="pspline">pspline</option>
+            <option value="lowess">lowess</option>
+            <option value="cofiam">cofiam</option>
+            <option value="supersmoother">supersmoother</option>
+            <option value="savgol">savgol</option>
+          </select>
         </div>
         <div>
           <div class="label-row">
             <label for="window_length">Window Length (days)</label>
-            <span class="help-tip" title="Window size for detrending in days. Leave blank for automatic selection based on the detected period.">?</span>
+            <span class="help-tip" tabindex="0" data-tip="Window size for detrending in days. Leave blank for automatic selection based on the detected period.">?</span>
           </div>
           <input type="number" step="0.01" name="window_length" id="window_length" placeholder="auto">
         </div>
         <div>
           <div class="label-row">
             <label for="gp_kernel">GP Kernel</label>
-            <span class="help-tip" title="Gaussian Process kernel for GP-based flattening. Options: periodic_auto, matern32, matern52, exp_sq.">?</span>
+            <span class="help-tip" tabindex="0" data-tip="Gaussian Process kernel for GP-based flattening. Only used when Flatten Method is 'gp'.">?</span>
           </div>
-          <input type="text" name="gp_kernel" id="gp_kernel" value="periodic_auto">
+          <select name="gp_kernel" id="gp_kernel">
+            <option value="periodic_auto" selected>periodic_auto</option>
+            <option value="periodic">periodic</option>
+            <option value="squared_exp">squared_exp</option>
+          </select>
         </div>
         <div>
           <div class="label-row">
             <label for="sigma_clip_flat">Sigma Clip Flat (lo hi)</label>
-            <span class="help-tip" title="Same format as raw. Applied after flattening. Leave blank to skip.">?</span>
+            <span class="help-tip" tabindex="0" data-tip="Two values (lo hi), same format as raw. Applied after flattening. Leave blank to skip.">?</span>
           </div>
           <input type="text" name="sigma_clip_flat" id="sigma_clip_flat" placeholder="none">
         </div>
@@ -395,7 +480,10 @@
     <div class="collapsible-content">
       <div class="form-grid">
         <div>
-          <label for="pg_method">Periodogram Method</label>
+          <div class="label-row">
+            <label for="pg_method">Periodogram Method</label>
+            <span class="help-tip" tabindex="0" data-tip="GLS = Generalised Lomb-Scargle, LS = classic Lomb-Scargle, BLS = Box Least Squares (transit-shaped; best for shallow transits).">?</span>
+          </div>
           <select name="pg_method" id="pg_method">
             {% for pg in ['gls','ls','bls'] %}
             <option value="{{pg}}">{{ pg | upper }}</option>
@@ -403,20 +491,27 @@
           </select>
         </div>
         <div>
-          <label for="period_min">Period Min (days)</label>
+          <div class="label-row">
+            <label for="period_min">Period Min (days)</label>
+            <span class="help-tip" tabindex="0" data-tip="Shortest trial period for the transit search. Default 0.1 days (~2.4 hr).">?</span>
+          </div>
           <input type="number" step="0.01" name="period_min" id="period_min" placeholder="0.1">
         </div>
         <div>
-          <label for="period_max">Period Max (days)</label>
+          <div class="label-row">
+            <label for="period_max">Period Max (days)</label>
+            <span class="help-tip" tabindex="0" data-tip="Longest trial period. Defaults to half the data baseline so at least two transits can be detected.">?</span>
+          </div>
           <input type="number" step="0.01" name="period_max" id="period_max" placeholder="baseline/2">
         </div>
         <div class="full-width checkbox-group" style="margin-top: 4px;">
           <label><input type="checkbox" name="mask_ephem"> Mask known transits (TOI/custom)</label>
+          <span class="help-tip" tabindex="0" data-tip="Remove cadences inside known transits (from the TOI catalog or the Custom Ephemeris field) before running the periodogram search.">?</span>
         </div>
         <div class="full-width">
           <div class="label-row">
             <label for="custom_ephem">Custom Ephemeris</label>
-            <span class="help-tip" title="Six space-separated values: Tc Tc_err Period Period_err Tdur Tdur_err (all in days, BJD for Tc).">?</span>
+            <span class="help-tip" tabindex="0" data-tip="Six space-separated values: Tc Tc_err Period Period_err Tdur Tdur_err (all in days, BJD for Tc).">?</span>
           </div>
           <input type="text" name="custom_ephem" id="custom_ephem" placeholder="Tc Tcerr P Perr Tdur Tdurerr">
         </div>
@@ -433,7 +528,10 @@
     <div class="collapsible-content">
       <div class="form-grid">
         <div>
-          <label for="survey">Archival Survey</label>
+          <div class="label-row">
+            <label for="survey">Archival Survey</label>
+            <span class="help-tip" tabindex="0" data-tip="Sky survey used for the archival image cutout shown in the QuickLook plot. DSS2 is a good general default.">?</span>
+          </div>
           <select name="survey" id="survey">
             {% for s in ['dss1','dss2','dss3','dss4','2mass','sdss','panstarrs'] %}
             <option value="{{s}}">{{ s | upper }}</option>
@@ -441,17 +539,32 @@
           </select>
         </div>
         <div>
-          <label for="suffix">Filename Suffix</label>
+          <div class="label-row">
+            <label for="suffix">Filename Suffix</label>
+            <span class="help-tip" tabindex="0" data-tip="Optional string appended to the output filename, useful for tagging runs (e.g. 'gp_test').">?</span>
+          </div>
           <input type="text" name="suffix" id="suffix" placeholder="optional">
         </div>
         <div class="full-width">
-          <label for="outdir">Output Directory</label>
+          <div class="label-row">
+            <label for="outdir">Output Directory</label>
+            <span class="help-tip" tabindex="0" data-tip="Where to save the PNG and TLS HDF5 files. Leave blank to use the app's default outputs folder.">?</span>
+          </div>
           <input type="text" name="outdir" id="outdir" placeholder="default: app outputs">
         </div>
         <div class="full-width checkbox-group">
-          <label><input type="checkbox" name="save" checked> Save outputs</label>
-          <label><input type="checkbox" name="verbose" checked> Verbose</label>
-          <label><input type="checkbox" name="overwrite"> Overwrite</label>
+          <label>
+            <input type="checkbox" name="save" checked> Save outputs
+            <span class="help-tip" tabindex="0" data-tip="Save the PNG figure and the TLS results HDF5 file to the output directory.">?</span>
+          </label>
+          <label>
+            <input type="checkbox" name="verbose" checked> Verbose
+            <span class="help-tip" tabindex="0" data-tip="Print detailed progress messages to the output log during the run.">?</span>
+          </label>
+          <label>
+            <input type="checkbox" name="overwrite"> Overwrite
+            <span class="help-tip" tabindex="0" data-tip="If an output file for this target already exists, re-run and replace it instead of skipping.">?</span>
+          </label>
         </div>
       </div>
     </div>
@@ -478,8 +591,13 @@
 
 <!-- Job queue -->
 <div id="queueSection" class="queue-section" style="display:none;">
-  <h2>Job Queue</h2>
+  <div class="queue-header">
+    <h2>Job Queue</h2>
+    <span class="queue-count" id="queueCount"></span>
+    <button type="button" class="queue-toggle" id="queueToggle"></button>
+  </div>
   <ul class="queue-list" id="queueList"></ul>
+  <div class="queue-hidden-hint" id="queueHiddenHint" style="display:none;"></div>
 </div>
 
 <!-- Status bar -->
@@ -487,6 +605,7 @@
   <div class="spinner" id="statusSpinner"></div>
   <span id="statusText"></span>
   <button class="btn btn-red btn-sm" id="cancelBtn" style="display:none;" type="button">Cancel</button>
+  <button class="btn btn-red btn-sm" id="cancelAllBtn" style="display:none;" type="button" title="Cancel all queued and running jobs">Cancel All Pending</button>
 </div>
 
 <!-- Progress -->
@@ -549,6 +668,7 @@ const statusBar = $('statusBar');
 const statusSpinner = $('statusSpinner');
 const statusText = $('statusText');
 const cancelBtn = $('cancelBtn');
+const cancelAllBtn = $('cancelAllBtn');
 const progressSection = $('progressSection');
 const progressWrap = $('progressWrap');
 const progressFill = $('progressFill');
@@ -562,6 +682,9 @@ const downloadH5 = $('downloadH5');
 const downloadImg = $('downloadImg');
 const queueSection = $('queueSection');
 const queueList = $('queueList');
+const queueCount = $('queueCount');
+const queueToggle = $('queueToggle');
+const queueHiddenHint = $('queueHiddenHint');
 const batchSection = $('batchSection');
 const batchTargets = $('batchTargets');
 const batchSubmitBtn = $('batchSubmitBtn');
@@ -573,6 +696,70 @@ const toastContainer = $('toastContainer');
 let activeWs = null;
 let activeTarget = null;
 let jobRunning = false;
+
+/* =========================================================================
+   Help tooltips (hover + click toggle, edge-aware positioning)
+   ========================================================================= */
+const TIP_MAX_WIDTH = 260;   // matches CSS max-width
+const TIP_EDGE_PAD = 8;      // viewport edge padding
+
+function positionTip(tip) {
+  // Measure the tooltip via a hidden clone so we get its real width,
+  // which is often less than TIP_MAX_WIDTH for short text.
+  const rect = tip.getBoundingClientRect();
+  const probe = document.createElement('span');
+  probe.textContent = tip.getAttribute('data-tip') || '';
+  probe.style.cssText =
+    'position:fixed;visibility:hidden;pointer-events:none;' +
+    'padding:6px 10px;font-size:0.75rem;line-height:1.4;' +
+    'max-width:' + TIP_MAX_WIDTH + 'px;width:max-content;white-space:normal;';
+  document.body.appendChild(probe);
+  const tipWidth = probe.getBoundingClientRect().width;
+  document.body.removeChild(probe);
+
+  const center = rect.left + rect.width / 2;
+  const halfTip = tipWidth / 2;
+  const vw = window.innerWidth;
+  let shift = 0;
+  if (center - halfTip < TIP_EDGE_PAD) {
+    shift = TIP_EDGE_PAD - (center - halfTip);
+  } else if (center + halfTip > vw - TIP_EDGE_PAD) {
+    shift = -((center + halfTip) - (vw - TIP_EDGE_PAD));
+  }
+  tip.style.setProperty('--tip-shift', shift + 'px');
+}
+
+document.addEventListener('mouseover', (e) => {
+  const tip = e.target.closest && e.target.closest('.help-tip');
+  if (tip) positionTip(tip);
+});
+document.addEventListener('focusin', (e) => {
+  if (e.target.classList && e.target.classList.contains('help-tip')) positionTip(e.target);
+});
+window.addEventListener('resize', () => {
+  document.querySelectorAll('.help-tip.active').forEach(positionTip);
+});
+
+document.addEventListener('click', (e) => {
+  const tip = e.target.closest('.help-tip');
+  if (tip) {
+    e.preventDefault();
+    e.stopPropagation();
+    const wasActive = tip.classList.contains('active');
+    document.querySelectorAll('.help-tip.active').forEach(t => t.classList.remove('active'));
+    if (!wasActive) {
+      positionTip(tip);
+      tip.classList.add('active');
+    }
+  } else {
+    document.querySelectorAll('.help-tip.active').forEach(t => t.classList.remove('active'));
+  }
+});
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') {
+    document.querySelectorAll('.help-tip.active').forEach(t => t.classList.remove('active'));
+  }
+});
 
 /* =========================================================================
    Dark mode
@@ -667,6 +854,66 @@ function resetFormDefaults() {
 loadFormState();
 resetBtn.addEventListener('click', resetFormDefaults);
 
+/* =========================================================================
+   Dependent field state — disable inputs whose value would be ignored
+   ========================================================================= */
+const FLUXTYPE_PIPELINES = ['spoc', 'tess-spoc'];
+
+function updateFieldStates() {
+  const eachSector = form.elements['each_sector'];
+  const sectorInput = form.elements['sector'];
+  if (eachSector && sectorInput) {
+    const disabled = eachSector.checked;
+    sectorInput.disabled = disabled;
+    sectorInput.title = disabled ? 'Ignored — "Run each available sector" is on' : '';
+    sectorInput.style.opacity = disabled ? '0.5' : '';
+  }
+
+  const pipeline = form.elements['pipeline'];
+  const fluxtype = form.elements['fluxtype'];
+  if (pipeline && fluxtype) {
+    const disabled = !FLUXTYPE_PIPELINES.includes(pipeline.value);
+    fluxtype.disabled = disabled;
+    fluxtype.title = disabled ? 'Ignored — only SPOC and TESS-SPOC pipelines have a flux-type choice' : '';
+    fluxtype.style.opacity = disabled ? '0.5' : '';
+  }
+
+  const flatten = form.elements['flatten_method'];
+  const gpKernel = form.elements['gp_kernel'];
+  if (flatten && gpKernel) {
+    const disabled = flatten.value !== 'gp';
+    gpKernel.disabled = disabled;
+    gpKernel.title = disabled ? 'Ignored — only used when Flatten Method is "gp"' : '';
+    gpKernel.style.opacity = disabled ? '0.5' : '';
+  }
+}
+
+form.elements['each_sector'].addEventListener('change', updateFieldStates);
+form.elements['pipeline'].addEventListener('change', updateFieldStates);
+form.elements['flatten_method'].addEventListener('change', updateFieldStates);
+updateFieldStates();
+
+/* Batch textarea persistence (independent of the main form) */
+const BATCH_STORAGE_KEY = 'ql-batch-targets';
+(function loadBatchState() {
+  const saved = localStorage.getItem(BATCH_STORAGE_KEY);
+  if (saved) {
+    batchTargets.value = saved;
+    // Auto-expand the batch section so the user sees the restored content
+    if (saved.trim()) {
+      batchSection.classList.add('visible');
+      $('batchToggleBtn').textContent = 'Hide batch mode';
+    }
+  }
+})();
+batchTargets.addEventListener('input', () => {
+  if (batchTargets.value) {
+    localStorage.setItem(BATCH_STORAGE_KEY, batchTargets.value);
+  } else {
+    localStorage.removeItem(BATCH_STORAGE_KEY);
+  }
+});
+
 // Save state on any input change
 form.addEventListener('input', saveFormState);
 form.addEventListener('change', saveFormState);
@@ -740,6 +987,7 @@ function setStatus(state, message) {
   statusSpinner.style.display = state === 'running' ? 'block' : 'none';
   statusText.textContent = message;
   cancelBtn.style.display = state === 'running' ? '' : 'none';
+  cancelAllBtn.style.display = state === 'running' ? '' : 'none';
 }
 
 function formatETA(seconds) {
@@ -771,6 +1019,28 @@ cancelBtn.addEventListener('click', () => {
     activeWs.send(JSON.stringify({action: 'cancel'}));
   }
   if (activeTarget) fetch('/cancel/' + activeTarget, {method: 'POST'});
+});
+
+cancelAllBtn.addEventListener('click', async () => {
+  if (!confirm('Cancel all queued and running jobs?')) return;
+  cancelAllBtn.disabled = true;
+  try {
+    const res = await fetch('/cancel-all', {method: 'POST'});
+    const data = await res.json();
+    if (data.ok) {
+      const n = (data.cancelled || []).length;
+      showToast(n ? 'Cancelled ' + n + ' pending job' + (n === 1 ? '' : 's') : 'No pending jobs', 'info');
+      if (activeWs && activeWs.readyState === WebSocket.OPEN) {
+        activeWs.send(JSON.stringify({action: 'cancel'}));
+      }
+      refreshQueue();
+    } else {
+      showToast('Cancel-all failed', 'error');
+    }
+  } catch (err) {
+    showToast('Network error: ' + err.message, 'error');
+  }
+  cancelAllBtn.disabled = false;
 });
 
 /* =========================================================================
@@ -940,6 +1210,32 @@ function formatTime(ts) {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
+const QUEUE_FOLD_THRESHOLD = 8;
+const isPending = (s) => s === 'queued' || s === 'running';
+let queueFoldMode = null; // null=auto, true=pending-only, false=show-all
+
+function setQueueFoldMode(mode) {
+  queueFoldMode = mode;
+  try { localStorage.setItem('queueFoldMode', mode === null ? 'auto' : String(mode)); } catch (e) {}
+  refreshQueue();
+}
+try {
+  const saved = localStorage.getItem('queueFoldMode');
+  if (saved === 'true') queueFoldMode = true;
+  else if (saved === 'false') queueFoldMode = false;
+} catch (e) {}
+
+queueToggle.addEventListener('click', () => {
+  // Toggle between pending-only and show-all (user intent overrides auto).
+  setQueueFoldMode(!resolveFolded());
+});
+
+function resolveFolded(total) {
+  if (queueFoldMode === true) return true;
+  if (queueFoldMode === false) return false;
+  return (total || 0) > QUEUE_FOLD_THRESHOLD;
+}
+
 async function refreshQueue() {
   try {
     const res = await fetch('/jobs-json');
@@ -947,8 +1243,17 @@ async function refreshQueue() {
     if (jobs.length === 0) { queueSection.style.display = 'none'; return; }
 
     queueSection.style.display = '';
+    const pendingCount = jobs.filter(j => isPending(j.status)).length;
+    const folded = resolveFolded(jobs.length);
+    const visibleJobs = folded ? jobs.filter(j => isPending(j.status)) : jobs;
+    const hiddenCount = jobs.length - visibleJobs.length;
+
+    queueCount.textContent =
+      pendingCount + ' pending / ' + jobs.length + ' total';
+    queueToggle.textContent = folded ? 'Show all' : 'Show pending only';
+
     queueList.innerHTML = '';
-    for (const job of jobs) {
+    for (const job of visibleJobs) {
       const li = document.createElement('li');
       li.className = 'queue-item';
 
@@ -972,6 +1277,17 @@ async function refreshQueue() {
       }
 
       queueList.appendChild(li);
+    }
+
+    if (folded && hiddenCount > 0) {
+      queueHiddenHint.textContent =
+        '+ ' + hiddenCount + ' finished job' + (hiddenCount === 1 ? '' : 's') + ' hidden';
+      queueHiddenHint.style.display = '';
+    } else if (folded && visibleJobs.length === 0) {
+      queueHiddenHint.textContent = 'No pending jobs. ' + jobs.length + ' finished.';
+      queueHiddenHint.style.display = '';
+    } else {
+      queueHiddenHint.style.display = 'none';
     }
   } catch (e) {
     console.error('Queue refresh failed:', e);

--- a/quicklook/cli/ql.py
+++ b/quicklook/cli/ql.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 import sys
 import argparse
 import subprocess
@@ -30,6 +31,7 @@ def run_ql_for_sector(
     mask_ephem,
     suffix,
     period_limits,
+    tls_use_threads,
 ):
     """Run ql for a single sector. Used by --each-sector."""
     ql = TessQuickLook(
@@ -57,6 +59,7 @@ def run_ql_for_sector(
         verbose=verbose,
         overwrite=overwrite,
         suffix=suffix,
+        tls_use_threads=tls_use_threads,
     )
     ql.plot_tql()
     if not save:
@@ -119,6 +122,20 @@ def main():
         default=1,
         help="number of parallel jobs (default=1)",
     )
+    parser.add_argument(
+        "--nice",
+        type=int,
+        default=None,
+        help="lower CPU priority by this increment (POSIX; e.g. 19 = lowest). "
+        "Default: unchanged.",
+    )
+    parser.add_argument(
+        "--cores",
+        type=int,
+        default=None,
+        help="CPU cores used by TLS per run. "
+        "Default: cpu_count//2 for single run; cpu_count//jobs for --each-sector.",
+    )
     # parser.add_argument(
     #     "-c",
     #     "--cadence",
@@ -145,7 +162,7 @@ def main():
         "--pipeline",
         type=str,
         help="lightcurve produced from which pipeline (default=SPOC)",
-        choices=["spoc", "tess-spoc", "tasoc", "cdips", "pathos", "qlp", "tglc"],
+        choices=["spoc", "tess-spoc", "tasoc", "cdips", "pathos", "qlp", "tglc", "t16"],
         default="SPOC",
     )
     parser.add_argument(
@@ -202,14 +219,28 @@ def main():
     parser.add_argument(
         "--flatten_method",
         type=str,
-        help="wotan flatten method (default=biweight)",
+        help="wotan flatten method (default=biweight); see https://wotan.readthedocs.io/en/latest/Usage.html",
         default="biweight",
+        choices=[
+            "biweight",
+            "gp",
+            "medfilt",
+            "median",
+            "rspline",
+            "hspline",
+            "pspline",
+            "lowess",
+            "cofiam",
+            "supersmoother",
+            "savgol",
+        ],
     )
     parser.add_argument(
         "--gp_kernel",
         type=str,
         help="wotan gp kernel (default=periodic_auto)",
         default="periodic_auto",
+        choices=["periodic_auto", "periodic", "squared_exp"],
     )
     parser.add_argument(
         "--gp_kernel_size",
@@ -308,7 +339,34 @@ def main():
     # prints help if no argument supplied
     args = parser.parse_args(None if sys.argv[1:] else ["-h"])
 
+    if args.nice is not None:
+        try:
+            new_nice = os.nice(args.nice)
+            if args.verbose:
+                print(f"Process niceness set to {new_nice}")
+        except (AttributeError, OSError) as e:
+            print(
+                f"Warning: could not apply --nice {args.nice}: {e}",
+                file=sys.stderr,
+            )
+
     target_name = sanitize_target_name(args.name)
+
+    cpu_total = os.cpu_count() or 1
+    if args.each_sector:
+        tls_use_threads = (
+            args.cores if args.cores is not None else max(1, cpu_total // max(1, args.jobs))
+        )
+    else:
+        tls_use_threads = args.cores if args.cores is not None else max(1, cpu_total // 2)
+    tls_use_threads = max(1, min(tls_use_threads, cpu_total))
+    if args.each_sector and args.jobs * tls_use_threads > cpu_total:
+        print(
+            f"Warning: jobs ({args.jobs}) * cores ({tls_use_threads}) = "
+            f"{args.jobs * tls_use_threads} exceeds cpu_count ({cpu_total}); "
+            "expect oversubscription.",
+            file=sys.stderr,
+        )
 
     if args.each_sector:
         sectors = get_available_sectors(target_name, pipeline=args.pipeline)
@@ -317,7 +375,7 @@ def main():
             sys.exit(1)
 
         print(f"Found {len(sectors)} sectors for {target_name}: {sectors}")
-        print(f"Running with {args.jobs} parallel job(s)...")
+        print(f"Running with {args.jobs} parallel job(s), {tls_use_threads} TLS core(s) each...")
 
         failed = 0
         with ProcessPoolExecutor(max_workers=args.jobs) as executor:
@@ -342,6 +400,7 @@ def main():
                     args.mask_ephem,
                     args.suffix,
                     args.period_limits,
+                    tls_use_threads,
                 )
                 futures[future] = sector
 
@@ -402,6 +461,7 @@ def main():
         verbose=args.verbose,
         overwrite=args.overwrite,
         suffix=args.suffix,
+        tls_use_threads=tls_use_threads,
         # check_if_variable=args.check_if_variable,
         # estimate_spec_type=args.spec_type,
         # estimate_gyro_age=args.gyro_age,

--- a/quicklook/gls.py
+++ b/quicklook/gls.py
@@ -189,19 +189,20 @@ class Gls:
             try:
                 self.df = lc
                 lc = np.genfromtxt(lc, unpack=True)[0:3]
-            except Exception as e:
-                print("An error occurred while trying to read data file:")
-                print("  ", e)
+            except (OSError, ValueError) as e:
+                raise OSError(f"Failed to read data file '{lc}': {e}") from e
 
         if isinstance(lc, (tuple, list, np.ndarray)):
             # t, y[, e_y] were given as list or tuple.
+            # Ensure plain numpy arrays (not astropy MaskedNDArray) to avoid
+            # broadcast failures in np.dot during peak fitting.
             if len(lc) in (2, 3):
-                self.t = np.ravel(lc[0])
-                self.y = np.ravel(lc[1])
+                self.t = np.asarray(np.ravel(lc[0]), dtype=float)
+                self.y = np.asarray(np.ravel(lc[1]), dtype=float)
                 self.e_y = None
                 if len(lc) == 3 and lc[2] is not None:
                     # Error has been specified.
-                    self.e_y = np.ravel(lc[2])
+                    self.e_y = np.asarray(np.ravel(lc[2]), dtype=float)
             else:
                 raise (
                     ValueError(
@@ -442,12 +443,8 @@ class Gls:
         if t is None:
             t = self.t
 
-        try:
-            p = self.best
-            return p["amp"] * sin(2 * np.pi * p["f"] * (t - p["T0"])) + p["offset"]
-        except Exception as e:
-            print("Failed to calcuate best-fit sine curve.")
-            raise (e)
+        p = self.best
+        return p["amp"] * sin(2 * np.pi * p["f"] * (t - p["T0"])) + p["offset"]
 
     def info(self, stdout=True):
         """

--- a/quicklook/plot.py
+++ b/quicklook/plot.py
@@ -22,6 +22,7 @@ from quicklook.utils import (
     TESS_pix_scale,
 )
 from quicklook.measure import find_contours
+from loguru import logger
 
 __all__ = [
     "use_style",
@@ -66,29 +67,38 @@ def plot_odd_even_transit(fold_lc, tls_results, bin_mins=10, markersize=6, ax=No
     clipped_lc = fold_lc[near_transit]
     clipped_lc.scatter(ax=ax, c="k", alpha=0.5, label="_nolegend_", zorder=1)
 
-    even_lc = clipped_lc[clipped_lc.even_mask]
-    odd_lc = clipped_lc[clipped_lc.odd_mask]
+    # Force writeable deep copies; stacked boolean slices on the folded
+    # LightCurve leave the underlying flux/time buffers non-writeable, which
+    # breaks the in-place ufuncs used by LightCurve.bin() under numpy >= 2.0.
+    even_lc = clipped_lc[clipped_lc.even_mask].copy()
+    odd_lc = clipped_lc[clipped_lc.odd_mask].copy()
 
     if len(even_lc) > 0:
-        even_lc.bin(time_bin_size=bin_mins * u.minute).errorbar(
-            label="even transit",
-            c="#1f77b4",
-            marker="o",
-            lw=2,
-            markersize=markersize,
-            ax=ax,
-            zorder=2,
-        )
+        try:
+            even_lc.bin(time_bin_size=bin_mins * u.minute).errorbar(
+                label="even transit",
+                c="#1f77b4",
+                marker="o",
+                lw=2,
+                markersize=markersize,
+                ax=ax,
+                zorder=2,
+            )
+        except (ValueError, TypeError) as e:
+            logger.debug(f"Could not bin even-transit data: {e}")
     if len(odd_lc) > 0:
-        odd_lc.bin(time_bin_size=bin_mins * u.minute).errorbar(
-            label="odd transit",
-            c="#d62728",
-            marker="o",
-            lw=2,
-            markersize=markersize,
-            ax=ax,
-            zorder=2,
-        )
+        try:
+            odd_lc.bin(time_bin_size=bin_mins * u.minute).errorbar(
+                label="odd transit",
+                c="#d62728",
+                marker="o",
+                lw=2,
+                markersize=markersize,
+                ax=ax,
+                zorder=2,
+            )
+        except (ValueError, TypeError) as e:
+            logger.debug(f"Could not bin odd-transit data: {e}")
 
     ax.plot(
         (tls_results.model_folded_phase - 0.5) * tls_results.period,
@@ -123,8 +133,8 @@ def plot_secondary_eclipse(flat_lc, tls_results, tmask, bin_mins=10, markersize=
     t14 = tls_results.duration
     try:
         secthresh = compute_secthresh(fold_lc2, t14)
-    except Exception as e:
-        print(e)
+    except (ValueError, ZeroDivisionError, IndexError) as e:
+        logger.debug(f"Could not compute secondary eclipse threshold: {e}")
         secthresh = np.nan
     # Clip to eclipse window before binning to avoid thousands of empty bins
     phase_lo = half_phase - t14 * 2
@@ -137,7 +147,7 @@ def plot_secondary_eclipse(flat_lc, tls_results, tmask, bin_mins=10, markersize=
         0,
         1,
         lw=2,
-        label=f"TLS depth={(1-yline)*1e3:.2f} ppt",
+        label=f"TLS depth={(1 - yline) * 1e3:.2f} ppt",
         c="k",
         ls="--",
     )
@@ -150,11 +160,11 @@ def plot_secondary_eclipse(flat_lc, tls_results, tmask, bin_mins=10, markersize=
                 marker="o",
                 markersize=markersize,
                 lw=2,
-                label=f"sec_eclipse_thresh={secthresh*1e3:.2f} ppt",
+                label=f"sec_eclipse_thresh={secthresh * 1e3:.2f} ppt",
                 zorder=2,
             )
-    except Exception as e:
-        print(e)
+    except (ValueError, TypeError) as e:
+        logger.debug(f"Could not bin secondary eclipse data: {e}")
     ax.set_xlabel("Orbital Phase")
     ax.set_xlim(phase_lo, phase_hi)
     ax.legend()
@@ -477,7 +487,10 @@ def plot_gaia_sources_on_tpf(
     # find sources within mask
     # target is assumed to be the first row
     idx = gaia_sources["source_id"].astype(int).isin([target_gaiaid])
-    target_gmag = gaia_sources.loc[idx, "phot_g_mean_mag"].values[0]
+    if idx.sum() == 0:
+        target_gmag = gaia_sources["phot_g_mean_mag"].min()
+    else:
+        target_gmag = gaia_sources.loc[idx, "phot_g_mean_mag"].values[0]
     # sources_inside_aperture = []
     if depth is not None:
         # compute delta mag limit given transit depth
@@ -684,9 +697,8 @@ def plot_gaia_sources_on_survey(
                 width=fov_rad.value,
                 height=fov_rad.value,
             )
-        except Exception:
-            errmsg = "survey image not available"
-            raise FileNotFoundError(errmsg)
+        except (OSError, ValueError, KeyError) as e:
+            raise FileNotFoundError("Survey image not available") from e
         fig = pl.figure(figsize=figsize)
         # define scaling in projection
         ax = fig.add_subplot(111, projection=WCS(hdu.header))
@@ -706,7 +718,10 @@ def plot_gaia_sources_on_survey(
         transform=ax.get_transform(WCS(maskhdr)),
     )
     idx = gaia_sources["source_id"].astype(int).isin([target_gaiaid])
-    target_gmag = gaia_sources.loc[idx, "phot_g_mean_mag"].values[0]
+    if idx.sum() == 0:
+        target_gmag = gaia_sources["phot_g_mean_mag"].min()
+    else:
+        target_gmag = gaia_sources.loc[idx, "phot_g_mean_mag"].values[0]
 
     for _, row in gaia_sources.iterrows():
         marker, s = "o", 100
@@ -799,11 +814,9 @@ def get_dss_data(
         if plot:
             _ = plot_dss_image(hdu)
         return hdu
-    except Exception as e:
-        if isinstance(e, OSError):
-            print(f"Error: {e}\nsurvey={survey} image is likely unavailable.")
-        else:
-            raise Exception(f"Error: {e}")
+    except OSError as e:
+        logger.warning(f"survey={survey} image is likely unavailable: {e}")
+        return None
 
 
 def plot_archival_images(
@@ -880,7 +893,7 @@ def plot_archival_images(
                 color=False,
             )
             img, hdr = ps.get_fits(filter=filter, verbose=False)
-        except Exception:
+        except ImportError:
             raise ModuleNotFoundError("pip install git+https://github.com/jpdeleon/panstarrs3.git")
 
     # poss1
@@ -908,9 +921,8 @@ def plot_archival_images(
             hdu2 = get_dss_data(ra, dec, height=height, width=width, survey=survey2)
     try:
         from reproject import reproject_interp
-    except Exception:
-        cmd = "pip install reproject"
-        raise ModuleNotFoundError(cmd)
+    except ImportError:
+        raise ModuleNotFoundError("pip install reproject")
 
     projected_img, footprint = reproject_interp(hdu2, hdu1.header)
 

--- a/quicklook/tglc.py
+++ b/quicklook/tglc.py
@@ -118,7 +118,7 @@ def mast_query(request):
     req_string = json.dumps(request)
     req_string = urlencode(req_string)
     # Perform the HTTP request
-    resp = requests.post(request_url, data="request=" + req_string, headers=headers)
+    resp = requests.post(request_url, data="request=" + req_string, headers=headers, timeout=60)
     # Pull out the headers and response content
     head = resp.headers
     content = resp.content.decode("utf-8")
@@ -226,7 +226,7 @@ class Source(object):
         catalog_3 = self.search_gaia(x, y, co2, co1)
         catalog_4 = self.search_gaia(x, y, co2, co2)
         catalogdata = vstack([catalog_1, catalog_2, catalog_3, catalog_4], join_type="exact")
-        catalogdata = unique(catalogdata, keys="DESIGNATION")
+        catalogdata = unique(catalogdata, keys="designation")
         coord = wcs.pixel_to_world([x + (size - 1) / 2 + 44], [y + (size - 1) / 2])[0].to_string()
         ra = float(coord.split()[0])
         dec = float(coord.split()[1])
@@ -256,10 +256,10 @@ class Source(object):
             if gaia_str != "None":
                 tic_lookup[gaia_str] = catalogdata_tic["ID"][idx_t]
         tic_id = np.zeros(len(catalogdata))
-        for i, designation in enumerate(catalogdata["DESIGNATION"]):
+        for i, designation in enumerate(catalogdata["designation"]):
             try:
                 tic_id[i] = tic_lookup.get(designation.split()[2], np.nan)
-            except Exception as e:
+            except (IndexError, ValueError, TypeError) as e:
                 logger.debug(f"TIC ID lookup failed for {designation}: {e}")
                 tic_id[i] = np.nan
 
@@ -287,8 +287,8 @@ class Source(object):
         t["tess_mag"] = tess_mag[in_frame]
         t["tess_flux"] = tess_flux[in_frame]
         t["tess_flux_ratio"] = tess_flux[in_frame] / np.nanmax(tess_flux[in_frame])
-        t["sector_{self.sector}_x"] = x_gaia[in_frame]
-        t["sector_{self.sector}_y"] = y_gaia[in_frame]
+        t[f"sector_{self.sector}_x"] = x_gaia[in_frame]
+        t[f"sector_{self.sector}_y"] = y_gaia[in_frame]
         catalogdata = hstack([catalogdata[in_frame], t])
         catalogdata.sort("tess_mag")
         self.gaia = catalogdata
@@ -517,7 +517,7 @@ class Source_cut(object):
         self.mask = mask
 
         gaia_targets = self.catalogdata[
-            "DESIGNATION",
+            "designation",
             "phot_g_mean_mag",
             "phot_bp_mean_mag",
             "phot_rp_mean_mag",
@@ -586,12 +586,12 @@ class Source_cut(object):
         t["tess_mag"] = tess_mag[in_frame]
         t["tess_flux"] = tess_flux[in_frame]
         t["tess_flux_ratio"] = tess_flux[in_frame] / np.max(tess_flux[in_frame])
-        t["sector_{self.sector}_x"] = x_gaia[in_frame]
-        t["sector_{self.sector}_y"] = y_gaia[in_frame]
+        t[f"sector_{self.sector}_x"] = x_gaia[in_frame]
+        t[f"sector_{self.sector}_y"] = y_gaia[in_frame]
         gaia_targets = hstack([gaia_targets[in_frame], t])
         if self.transient is not None:
             gaia_targets["tess_flux"][
-                np.where(gaia_targets["DESIGNATION"] == self.transient[0])[0][0]
+                np.where(gaia_targets["designation"] == self.transient[0])[0][0]
             ] = 0
         gaia_targets.sort("tess_mag")
         self.gaia = gaia_targets
@@ -693,7 +693,7 @@ def lc_output(
     :return:
     """
     if transient is None:
-        objid = [int(s) for s in (source.gaia[index]["DESIGNATION"]).split() if s.isdigit()][0]
+        objid = [int(s) for s in (source.gaia[index]["designation"]).split() if s.isdigit()][0]
     else:
         objid = transient[0]
     # source_path = f"{local_directory}hlsp_tglc_tess_ffi_gaiaid-{objid}-s{source.sector:04d}-cam{source.camera}-ccd{source.ccd}_tess_v1_llc.fits"
@@ -727,12 +727,12 @@ def lc_output(
         cal_aper_err = "NaN"
     try:
         ticid = str(source.tic["TIC"][np.where(source.tic["dr3_source_id"] == objid)][0])
-    except Exception as e:
+    except (IndexError, KeyError, TypeError) as e:
         logger.debug(f"TIC ID lookup failed for {objid}: {e}")
         ticid = ""
     try:
         raw_flux = np.nanmedian(source.flux[:, star_y, star_x])
-    except Exception as e:
+    except (IndexError, ValueError) as e:
         logger.debug(f"Raw flux extraction failed: {e}")
         raw_flux = None
     if save_aper:
@@ -774,7 +774,7 @@ def lc_output(
             fits.Card("FILTER", "TESS", "the filter used for the observations"),
             fits.Card(
                 "OBJECT",
-                source.gaia[index]["DESIGNATION"],
+                source.gaia[index]["designation"],
                 "string version of Gaia DR3 ID",
             ),
             fits.Card("GAIADR3", objid, "integer version of Gaia DR3 ID"),
@@ -865,7 +865,7 @@ def lc_output(
     table_hdu.header.append(
         (
             "OBJECT",
-            source.gaia[index]["DESIGNATION"],
+            source.gaia[index]["designation"],
             "string version of Gaia DR3 ID",
         ),
         end=True,
@@ -1003,7 +1003,7 @@ def get_psf(source, factor=2, psf_size=11, edge_compression=1e-4, c=np.array([0,
     coord = np.arange(size**2).reshape(size, size)
     xx, yy = np.meshgrid((np.arange(size) - (size - 1) / 2), (np.arange(size) - (size - 1) / 2))
 
-    if isinstance(Source, source):
+    if isinstance(source, Source):
         bg_dof = 6
         A = np.zeros((size**2, over_size**2 + bg_dof))
         A[:, -1] = np.ones(size**2)
@@ -1166,7 +1166,7 @@ def fit_lc(
     up_11 = np.minimum(size - y + 5, 11)
     coord = np.arange(psf_size**2).reshape(psf_size, psf_size)
     index = coord[down_11:up_11, left_11:right_11]
-    if isinstance(Source, source):
+    if isinstance(source, Source):
         bg_dof = 6
     else:
         bg_dof = 3
@@ -1309,7 +1309,7 @@ def fit_lc_float_field(
     # right_ = right - x[star_num] + 5
     # down_ = down - y[star_num] + 5
     # up_ = up - y[star_num] + 5
-    if isinstance(Source, source):
+    if isinstance(source, Source):
         bg_dof = 6
     else:
         bg_dof = 3
@@ -1640,16 +1640,16 @@ def epsf(
         try:
             start = int(
                 np.where(
-                    source.gaia["DESIGNATION"]
+                    source.gaia["designation"]
                     == "Gaia DR3 "
                     + str(source.tic["dr3_source_id"][np.where(source.tic["TIC"] == name)][0])
                 )[0][0]
             )
             end = start + 1
-        except Exception as e:
-            logger.debug(e)
+        except (IndexError, KeyError, TypeError, ValueError) as e:
+            logger.debug(f"TIC-to-Gaia lookup failed: {e}")
             try:
-                start = int(np.where(source.gaia["DESIGNATION"] == name)[0][0])
+                start = int(np.where(source.gaia["designation"] == name)[0][0])
                 end = start + 1
             except IndexError:
                 logger.warning(
@@ -1664,7 +1664,7 @@ def epsf(
             x_left <= x_round[i] < source.size - x_right
             and y_left <= y_round[i] < source.size - y_right
         ):
-            if isinstance(Source, source):
+            if isinstance(source, Source):
                 x_left = 1.5
                 x_right = 2.5
                 y_left = 1.5
@@ -1747,7 +1747,7 @@ def epsf(
             if np.isnan(aper_lc).all():
                 continue
             else:
-                if isinstance(Source, source):
+                if isinstance(source, Source):
                     # if cut_x >= 7:
                     #     lc_directory = f'{local_directory}lc/{source.camera}-{source.ccd}_extra/'
                     lc_output(
@@ -1811,7 +1811,7 @@ def epsf(
                     )
 
 
-def get_tglc_lc(target_name, sector=None, size=25, limit_mag=16, verbose=True):
+def get_tglc_lc(target_name, sector=None, size=50, limit_mag=16, verbose=True):
     """Run the TGLC ePSF pipeline for a single target and return a TessLightCurve.
 
     This function downloads an FFI cutout via TESScut, runs the TGLC effective
@@ -1920,7 +1920,7 @@ def get_tglc_lc(target_name, sector=None, size=25, limit_mag=16, verbose=True):
     )
 
     # 8. Build the TessLightCurve
-    flux = cal_psf_lc
+    flux = cal_psf_lc  # cal_aper_lc
     flux_err = np.full_like(flux, 1.4826 * np.nanmedian(np.abs(flux - np.nanmedian(flux))))
 
     # BTJD times (TESS Barycentric Julian Date, BJD - 2457000)

--- a/quicklook/tql.py
+++ b/quicklook/tql.py
@@ -1,14 +1,8 @@
 """
-1. See:
-* https://ui.adsabs.harvard.edu/abs/2021ascl.soft01011R/abstract
-* https://deep-lightcurve.readthedocs.io/en/latest/notebooks/Quickstart.html
-* https://ui.adsabs.harvard.edu/abs/2022MNRAS.516.4432M/abstract
-2. Add momentum dumps as in TESSLatte:
+TODO:
+* Add momentum dumps as in TESSLatte:
 https://github.com/noraeisner/LATTE/blob/7ac35c8a51949345bc076fd30a456e74fce70c51/LATTE/LATTEutils.py#L3501C13-L3501C63
-3. Add RUWE in plots
-4. ingest functions from target.py:
-http://localhost:9995/lab/workspaces/auto-q/tree/chronos/chronos/target.py
-
+* Add RUWE in plots
 """
 
 import math
@@ -95,6 +89,7 @@ class TessQuickLook:
         suffix: str = None,
         quality_bitmask: str = "default",
         outdir: str = ".",
+        tls_use_threads: int = None,
     ):
         # start timer
         self.timer_start = timer()
@@ -114,6 +109,7 @@ class TessQuickLook:
         self.sigma_clip_flat = sigma_clip_flat
         self.quality_bitmask = quality_bitmask
         self.flatten_method = flatten_method
+        self.tls_use_threads = tls_use_threads
         self.raw_lc = self.get_lc(
             author=pipeline,
             sector=sector,
@@ -752,15 +748,18 @@ class TessQuickLook:
         else:
             flux_err = self.flat_lc.flux_err.value
         # Run TLS
+        power_kwargs = {
+            "period_min": self.Porb_min,  # Roche limit default
+            "period_max": self.Porb_max,
+        }
+        if self.tls_use_threads is not None:
+            power_kwargs["use_threads"] = self.tls_use_threads
         self.tls_results = tls(
             self.flat_lc.time.value,
             self.flat_lc.flux.value,
             flux_err,
             verbose=self.verbose,
-        ).power(
-            period_min=self.Porb_min,  # Roche limit default
-            period_max=self.Porb_max,
-        )
+        ).power(**power_kwargs)
 
     def init_gls(self):
         masked_lc = self.raw_lc[~self.tmask]
@@ -1269,13 +1268,13 @@ class TessQuickLook:
             logger.info("Plotting TPF...")
         ax = axes.flatten()[5]
         if self.pipeline in [
-            "cdips",  # TODO: missing flux err raises error in errorbar plot
+            # "cdips",  # TODO: missing flux err raises error in errorbar plot
             "gsfc-eleanor-lite",
         ]:
             err_msg = "Pipeline to be added soon."
             logger.info(err_msg)
             raise NotImplementedError(err_msg)
-        elif self.pipeline in ["qlp", "cdips", "tasoc", "pathos", "tglc"]:
+        elif self.pipeline in ["qlp", "cdips", "tasoc", "pathos", "tglc", "t16"]:
             if self.verbose:
                 logger.info("Getting TPF with tesscut...")
             self.tpf = self.get_tpf_tesscut()

--- a/quicklook/utils.py
+++ b/quicklook/utils.py
@@ -28,6 +28,29 @@ __all__ = [
 ]
 
 
+def _get_tglc_sectors_via_tesscut(target_name, tic_id=None):
+    """Enumerate TESS sectors covering a target using the TESScut service.
+
+    Avoids the MAST Observations portal (`/api/v0/invoke`) so it survives
+    outages of that subsystem. TGLC runs locally on FFI cutouts, so sector
+    availability is driven purely by sky coverage, not by any pipeline
+    products existing on MAST.
+    """
+    from astropy.coordinates import SkyCoord
+    from astroquery.mast import Tesscut
+
+    if tic_id is not None:
+        resolve_name = f"TIC {tic_id}"
+    else:
+        resolve_name = target_name.replace("_", " ").replace("-", " ")
+
+    coord = SkyCoord.from_name(resolve_name)
+    sector_table = Tesscut.get_sectors(coordinates=coord)
+    if len(sector_table) == 0:
+        return []
+    return sorted({int(s) for s in sector_table["sector"]})
+
+
 def get_available_sectors(target_name, pipeline="SPOC", tic_id=None):
     """Query available sectors for target+pipeline.
 
@@ -46,6 +69,9 @@ def get_available_sectors(target_name, pipeline="SPOC", tic_id=None):
         Sorted list of unique sector numbers available for the target and pipeline.
     """
     import lightkurve as lk
+
+    if pipeline.upper() == "TGLC":
+        return _get_tglc_sectors_via_tesscut(target_name, tic_id=tic_id)
 
     # Resolve to TIC ID via ExoFOP, matching TessQuickLook behavior
     if tic_id is not None:
@@ -74,13 +100,6 @@ def get_available_sectors(target_name, pipeline="SPOC", tic_id=None):
     sectors = []
     for mission, author in zip(df["mission"].tolist(), df["provenance_name"].tolist()):
         if author.lower() == pipeline.lower():
-            x = mission.split()
-            if len(x) == 3:
-                sectors.append(int(x[-1]))
-
-    # TGLC can run locally on any FFI sector, so fall back to all sectors
-    if not sectors and pipeline.upper() == "TGLC":
-        for mission in df["mission"].tolist():
             x = mission.split()
             if len(x) == 3:
                 sectors.append(int(x[-1]))


### PR DESCRIPTION
GUI (quicklook/app/templates/index.html)
- Add "Cancel All Pending" button beside the single Cancel button that
  posts to the new /cancel-all endpoint, with a confirm dialog and a
  toast showing the number of jobs cancelled.
- Add "t16" to the Pipeline dropdown (the CLI already accepted it).
- Persist the Batch Submission textarea across page navigation via
  localStorage; auto-expand the section when restored content is
  non-empty.
- Replace the unreliable native title tooltip on the help "?" icons
  with a custom CSS+JS popover that works on hover, on click (toggle),
  and on keyboard focus. A positionTip() helper measures the tooltip
  via a hidden probe and sets a CSS --tip-shift variable so popovers
  near the viewport edge slide inward instead of being cropped.
- Remove overflow:hidden from .collapsible so tooltips can escape the
  section box; preserve the rounded look with header-only
  border-radius.
- Add help-tips with useful text to every form field that lacked one:
  Pipeline, Flux Type, Quality Bitmask, Edge Cutoff, Flatten Method,
  Periodogram Method, Period Min, Period Max, Mask Known Transits,
  Archival Survey, Filename Suffix, Output Directory, Save outputs,
  Verbose, Overwrite, and Run each available sector.
- Disable dependent fields whose values would be ignored:
    * Sector is disabled when "Run each available sector" is checked.
    * Flux Type is disabled when Pipeline is neither spoc nor
      tess-spoc (matches the gate in quicklook/tql.py:951).
    * GP Kernel is disabled when Flatten Method is not "gp".
  Each disabled input gets a greyed-out style and an explanatory
  title attribute.
- Convert Exposure Time from a free-form number input to a dropdown
  with options 20, 120, 200, 600, 1800 plus a blank "auto" entry.

Backend (quicklook/app/app.py)
- Add POST /cancel-all that iterates the jobs dict, sets every
  queued/running job's cancel_event, marks status "cancelled", and
  returns {ok: true, cancelled: [names]}. Mirrors the semantics of
  the existing /cancel/<target> route.

Bug fix (quicklook/plot.py)
- Fix "ValueError: output array is read-only" that killed entire
  QuickLook runs during "Plotting odd-even transit..." (e.g.
  TIC-284200852).
- Cause: stacked boolean slices on a folded LightCurve leave its
  Time/Quantity columns non-writeable. LightCurve.bin() delegates to
  astropy.timeseries.aggregate_downsample, which uses ufuncs with
  out=<array>; under numpy>=2.0 writing to a non-writeable view
  raises ValueError. tql.py had no try/except around the call, so
  the whole job died.
- Fix: deep-copy even_lc and odd_lc with .copy() after slicing so the
  ufuncs have writeable buffers, and wrap each .bin().errorbar()
  block in try/except (ValueError, TypeError) with a debug-log
  fallback. Mirrors the existing pattern in plot_secondary_eclipse.