### PR TITLE
Upgrade

### DIFF
--- a/quicklook/app/app.py
+++ b/quicklook/app/app.py
@@ -8,6 +8,7 @@ import sqlite3
 import sys
 import threading
 import time
+import traceback
 from collections import OrderedDict
 from pathlib import Path
 from threading import Thread, Event
@@ -336,9 +337,12 @@ def run_quicklook_background(name, cancel_event, **kwargs):
         jobs[name]["error"] = str(e)
         logger.warning(f"Job failed: {e}")
     except Exception as e:
+        tb = traceback.format_exc()
         jobs[name]["status"] = "error"
+        # Keep the short message for the GUI badge, but include the traceback
+        # so the per-target .log captures the offending file/line.
         jobs[name]["error"] = str(e)
-        logger.error(f"Job '{name}' failed unexpectedly: {e}")
+        logger.error(f"Job '{name}' failed unexpectedly: {e}\n{tb}")
     finally:
         # Tear down in safe order: streams first, then loguru sink, then file
         _tls_stdout.clear_stream()
@@ -758,12 +762,21 @@ def ws_log(ws, target):
         time.sleep(1.5)
 
 
+GALLERY_PER_PAGE_CHOICES = [12, 24, 48, 96, 192]
+GALLERY_PER_PAGE_DEFAULT = 24
+
+
 @app.route("/gallery")
 def gallery():
     search_name = request.args.get("search", "")
     sort_by = request.args.get("sort", "date_desc")
     page = max(1, int(request.args.get("page", 1)))
-    per_page = 24
+    try:
+        per_page = int(request.args.get("per_page", GALLERY_PER_PAGE_DEFAULT))
+    except (TypeError, ValueError):
+        per_page = GALLERY_PER_PAGE_DEFAULT
+    if per_page not in GALLERY_PER_PAGE_CHOICES:
+        per_page = GALLERY_PER_PAGE_DEFAULT
 
     images = list(OUTPUT_DIR.glob("*.png"))
 
@@ -795,6 +808,372 @@ def gallery():
         page=page,
         total_pages=total_pages,
         total=total,
+        per_page=per_page,
+        per_page_choices=GALLERY_PER_PAGE_CHOICES,
+    )
+
+
+def _parse_tls_filename(stem):
+    """Best-effort parse of pipeline, flux_type, cadence from a TLS filename.
+
+    Filenames follow `{name}_s{NN}_{lctype}_{c}c[_mask_ephem][_{suffix}]_tls`
+    (see TessQuickLook.check_output_file_exists). ``lctype`` is the flux type
+    when pipeline=="spoc" (pdcsap/sap), else the pipeline name itself.
+    Returns a dict of fallbacks; values are None when not confidently
+    recoverable.
+    """
+    SPOC_FLUX = {"pdcsap", "sap"}
+    HLSP_PIPELINES = {"qlp", "tglc", "tasoc", "cdips", "pathos", "tess-spoc", "t16"}
+    # Trailing "_tls" already stripped by Path.stem callers
+    if stem.endswith("_tls"):
+        stem = stem[: -len("_tls")]
+    tokens = stem.split("_")
+    pipeline = flux_type = cadence = None
+    # Find the sector token (sNN) and the cadence token ((s|l)c).
+    sec_idx = next((i for i, t in enumerate(tokens) if re.fullmatch(r"s\d{1,3}", t)), None)
+    cad_idx = next((i for i, t in enumerate(tokens) if re.fullmatch(r"[sl]c", t)), None)
+    if sec_idx is not None and cad_idx is not None and cad_idx > sec_idx + 1:
+        lctype = tokens[sec_idx + 1]
+        if lctype in SPOC_FLUX:
+            pipeline, flux_type = "spoc", lctype
+        elif lctype in HLSP_PIPELINES:
+            pipeline = lctype
+        cadence = "short" if tokens[cad_idx] == "sc" else "long"
+    return {"pipeline": pipeline, "flux_type": flux_type, "cadence": cadence}
+
+
+def _coerce_scalar(val):
+    """Unwrap 0-d/1-elem numpy arrays so Jinja sees a plain Python scalar."""
+    if val is None:
+        return None
+    try:
+        import numpy as _np
+
+        if isinstance(val, _np.ndarray):
+            if val.ndim == 0:
+                return val.item()
+            if val.size == 1:
+                return val.flat[0].item()
+    except Exception:
+        pass
+    if isinstance(val, bytes):
+        try:
+            return val.decode()
+        except Exception:
+            return None
+    return val
+
+
+def _get_allowed_browse_roots():
+    """Roots the /list-dirs endpoint is allowed to descend into.
+
+    Defaults to the user's home directory. Override via the
+    ``ALLOWED_BROWSE_ROOTS`` env var, colon-separated absolute paths.
+    """
+    env = os.environ.get("ALLOWED_BROWSE_ROOTS", "")
+    if env.strip():
+        roots = []
+        for part in env.split(":"):
+            part = part.strip()
+            if not part:
+                continue
+            try:
+                roots.append(Path(part).expanduser().resolve())
+            except (OSError, ValueError):
+                continue
+        if roots:
+            return roots
+    return [Path.home().resolve()]
+
+
+def _is_under_allowed_root(p, roots):
+    """True if the resolved path is inside any allowed root (or equals one)."""
+    try:
+        p_resolved = p.resolve()
+    except (OSError, ValueError):
+        return False
+    for root in roots:
+        try:
+            if p_resolved == root or p_resolved.is_relative_to(root):
+                return True
+        except (OSError, ValueError):
+            continue
+    return False
+
+
+@app.route("/list-dirs")
+def list_dirs():
+    """List immediate subdirectories of a path. Localhost-only convenience
+    for the TLS Summary directory picker — scoped to allowed roots so a
+    misconfigured deployment cannot leak arbitrary filesystem layout.
+    """
+    roots = _get_allowed_browse_roots()
+    req = request.args.get("path", "").strip()
+
+    if not req:
+        p = roots[0]
+    else:
+        try:
+            p = Path(req).expanduser()
+        except (OSError, ValueError):
+            return (
+                jsonify(
+                    {
+                        "error": "Invalid path",
+                        "entries": [],
+                        "path": req,
+                        "parent": None,
+                        "breadcrumbs": [],
+                        "roots": [str(r) for r in roots],
+                    }
+                ),
+                400,
+            )
+
+    if not _is_under_allowed_root(p, roots):
+        return (
+            jsonify(
+                {
+                    "error": "Path outside allowed roots",
+                    "entries": [],
+                    "path": str(p),
+                    "parent": None,
+                    "breadcrumbs": [],
+                    "roots": [str(r) for r in roots],
+                }
+            ),
+            403,
+        )
+
+    try:
+        p = p.resolve()
+    except (OSError, ValueError) as e:
+        return (
+            jsonify(
+                {
+                    "error": f"Cannot resolve path: {e}",
+                    "entries": [],
+                    "path": str(p),
+                    "parent": None,
+                    "breadcrumbs": [],
+                    "roots": [str(r) for r in roots],
+                }
+            ),
+            400,
+        )
+
+    if not p.is_dir():
+        return (
+            jsonify(
+                {
+                    "error": "Not a directory",
+                    "entries": [],
+                    "path": str(p),
+                    "parent": str(p.parent),
+                    "breadcrumbs": [],
+                    "roots": [str(r) for r in roots],
+                }
+            ),
+            400,
+        )
+
+    entries = []
+    has_tls_here = False
+    try:
+        for entry in os.scandir(p):
+            try:
+                if entry.is_dir(follow_symlinks=False) and not entry.name.startswith("."):
+                    sub = Path(entry.path)
+                    try:
+                        has_tls = any(sub.glob("*_tls.h5"))
+                    except (OSError, PermissionError):
+                        has_tls = False
+                    entries.append(
+                        {
+                            "name": entry.name,
+                            "path": str(sub.resolve()),
+                            "has_tls": has_tls,
+                        }
+                    )
+                elif entry.is_file(follow_symlinks=False) and entry.name.endswith("_tls.h5"):
+                    has_tls_here = True
+            except (OSError, PermissionError):
+                continue
+    except (OSError, PermissionError) as e:
+        return jsonify(
+            {
+                "error": f"Cannot list directory: {e}",
+                "entries": [],
+                "path": str(p),
+                "parent": str(p.parent),
+                "breadcrumbs": [],
+                "roots": [str(r) for r in roots],
+            }
+        )
+
+    entries.sort(key=lambda e: e["name"].lower())
+
+    # Parent only if still inside an allowed root
+    parent = None
+    if p != p.parent and _is_under_allowed_root(p.parent, roots):
+        try:
+            parent = str(p.parent.resolve())
+        except (OSError, ValueError):
+            parent = None
+
+    # Breadcrumb path: walk up while still under an allowed root
+    breadcrumbs = []
+    current = p
+    seen = set()
+    while True:
+        if str(current) in seen:
+            break
+        seen.add(str(current))
+        breadcrumbs.append({"name": current.name or str(current), "path": str(current)})
+        if current == current.parent or not _is_under_allowed_root(current.parent, roots):
+            break
+        current = current.parent
+    breadcrumbs.reverse()
+
+    return jsonify(
+        {
+            "path": str(p),
+            "parent": parent,
+            "entries": entries,
+            "has_tls_here": has_tls_here,
+            "breadcrumbs": breadcrumbs,
+            "roots": [str(r) for r in roots],
+            "error": None,
+        }
+    )
+
+
+@app.route("/tls-summary")
+def tls_summary():
+    """Sortable, searchable summary table of every saved TLS .h5 result.
+
+    Reads from ``OUTPUT_DIR`` by default; accepts ``?dir=<absolute_path>``
+    to point at any other directory containing ``*_tls.h5`` files.
+    """
+    from quicklook import h5io
+
+    req_dir = request.args.get("dir", "").strip()
+    chosen_dir = OUTPUT_DIR
+    dir_error = None
+    if req_dir:
+        try:
+            candidate = Path(req_dir).expanduser().resolve()
+        except (OSError, ValueError, RuntimeError):
+            candidate = None
+            dir_error = f"Invalid path: {req_dir}"
+        if candidate is not None:
+            if candidate.is_dir():
+                chosen_dir = candidate
+            else:
+                dir_error = f"Path not found or not a directory: {req_dir}"
+
+    is_default_dir = chosen_dir.resolve() == OUTPUT_DIR.resolve()
+    output_root = OUTPUT_DIR.resolve()
+
+    files = sorted(chosen_dir.glob("*_tls.h5"), key=os.path.getmtime, reverse=True)
+    rows = []
+    skipped = []
+    for fp in files:
+        try:
+            data = h5io.load(str(fp))
+        except Exception as e:
+            skipped.append({"name": fp.name, "error": str(e)})
+            continue
+
+        stem = fp.stem  # foo_s12_pdcsap_sc_tls
+        png_name = stem[: -len("_tls")] + ".png" if stem.endswith("_tls") else stem + ".png"
+
+        # Emit /static/outputs/... URLs only when the file lives inside
+        # OUTPUT_DIR; otherwise show the absolute path as plain text so we
+        # don't have to add a generic file-streaming endpoint.
+        try:
+            fp_resolved = fp.resolve()
+            external = not fp_resolved.is_relative_to(output_root)
+        except (OSError, ValueError):
+            external = True
+            fp_resolved = fp
+
+        if external:
+            png_path = None
+            h5_path = None
+            disk_path = str(fp_resolved)
+        else:
+            png_path = f"/static/outputs/{png_name}" if (OUTPUT_DIR / png_name).exists() else None
+            h5_path = f"/static/outputs/{fp.name}"
+            disk_path = None
+
+        def first(seq):
+            try:
+                return seq[0] if seq is not None and len(seq) > 0 else None
+            except Exception:
+                return None
+
+        ptc = data.get("per_transit_count")
+        try:
+            ptc_str = ",".join(str(int(x)) for x in ptc) if ptc is not None else ""
+        except Exception:
+            ptc_str = str(ptc) if ptc is not None else ""
+
+        # Filename-based fallbacks for older h5 files that pre-date the
+        # "save pipeline/flux_type/exptime/cadence" fix in tql.py.
+        fallback = _parse_tls_filename(stem)
+        pipeline = _coerce_scalar(data.get("pipeline")) or fallback["pipeline"]
+        flux_type = _coerce_scalar(data.get("flux_type")) or fallback["flux_type"]
+        exptime = _coerce_scalar(data.get("exptime"))
+        if exptime is None and fallback["cadence"] == "short":
+            # Use a hint, not a hard claim; surface in the table so users
+            # know it's inferred. 120s is the typical SPOC 2-min cadence.
+            exptime_hint = 120 if pipeline == "spoc" else None
+            exptime = exptime_hint
+
+        depth = data.get("depth")
+        duration_days = _coerce_scalar(data.get("duration"))
+        rows.append(
+            {
+                "filename": fp.name,
+                "stem": stem,
+                "png": png_path,
+                "h5": h5_path,
+                "external": external,
+                "disk_path": disk_path,
+                "mtime": os.path.getmtime(fp),
+                "toi": _coerce_scalar(data.get("toiid")),
+                "tic": _coerce_scalar(data.get("ticid")),
+                "gaiaid": _coerce_scalar(data.get("gaiaid")),
+                "pipeline": pipeline,
+                "flux_type": flux_type,
+                "exptime": exptime,
+                "sector": _coerce_scalar(data.get("sector")),
+                "Porb": _coerce_scalar(data.get("period")),
+                "duration_hr": duration_days * 24.0 if duration_days is not None else None,
+                "rp_rs": _coerce_scalar(data.get("rp_rs")),
+                "SDE": _coerce_scalar(data.get("SDE")),
+                "snr": _coerce_scalar(data.get("snr")),
+                "FAP": _coerce_scalar(data.get("FAP")),
+                "odd_even": _coerce_scalar(data.get("odd_even_mismatch")),
+                "n_tr": _coerce_scalar(data.get("distinct_transit_count")),
+                "depth_ppt": (1 - depth) * 1e3 if depth is not None else None,
+                "Prot_gls": first(data.get("Prot_gls")),
+                "amp_gls": first(data.get("amp_gls")),
+                "power_gls": first(data.get("power_gls")),
+                "per_transit_count": ptc_str,
+                "simbad_obj": _coerce_scalar(data.get("simbad_obj")),
+            }
+        )
+
+    return render_template(
+        "tls_summary.html",
+        rows=rows,
+        total=len(rows),
+        skipped=skipped,
+        current_dir=str(chosen_dir),
+        is_default_dir=is_default_dir,
+        dir_error=dir_error,
     )
 
 

--- a/quicklook/app/templates/compare.html
+++ b/quicklook/app/templates/compare.html
@@ -110,6 +110,30 @@
       border-radius: 50%; animation: spin 0.8s linear infinite; flex-shrink: 0;
     }
     @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* Shared full-page loading overlay (matches index / gallery / tls_summary) */
+    .page-loading {
+      position: fixed; inset: 0; background: rgba(0,0,0,0.45);
+      display: none; align-items: center; justify-content: center;
+      z-index: 2000; backdrop-filter: blur(2px);
+    }
+    .page-loading.show { display: flex; }
+    .page-loading .panel {
+      background: var(--card-bg); border: 1px solid var(--border);
+      border-radius: 10px; padding: 18px 22px;
+      display: flex; align-items: center; gap: 14px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.25);
+      min-width: 280px; max-width: 92%;
+    }
+    .page-loading .pl-spinner {
+      width: 22px; height: 22px; flex-shrink: 0;
+      border: 3px solid var(--primary); border-top-color: transparent;
+      border-radius: 50%; animation: spin 0.8s linear infinite;
+    }
+    .page-loading .text { display: flex; flex-direction: column; gap: 2px; }
+    .page-loading .text strong { font-size: 0.95rem; }
+    .page-loading .text small { font-size: 0.78rem; color: var(--text-sec); }
+
     .running-banner a { color: var(--primary); font-weight: 600; text-decoration: none; }
     .running-banner a:hover { text-decoration: underline; }
     .running-banner .job-list { display: flex; gap: 8px; flex-wrap: wrap; }
@@ -134,6 +158,7 @@
     <div class="top-bar-left">
       <a href="{{ url_for('index') }}" class="btn btn-primary">&larr; Back</a>
       <a href="{{ url_for('gallery') }}" class="btn btn-outline">Gallery</a>
+      <a href="{{ url_for('tls_summary') }}" class="btn btn-outline" id="summaryLink">Summary</a>
       <button class="theme-toggle" id="themeToggle" title="Toggle dark mode">&#9790;</button>
     </div>
   </div>
@@ -297,6 +322,29 @@
     }
     pollRunningJobs();
     setInterval(pollRunningJobs, 5000);
+
+    /* Show the shared loading overlay when navigating to the (potentially
+       slow) TLS Summary page. The overlay markup is parsed after this
+       script, so we look it up lazily inside the click handler. */
+    (function () {
+      const link = document.getElementById('summaryLink');
+      if (!link) return;
+      link.addEventListener('click', (e) => {
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return;
+        const overlay = document.getElementById('pageLoading');
+        if (overlay) overlay.classList.add('show');
+      });
+    })();
   </script>
+
+  <div class="page-loading" id="pageLoading" role="status" aria-live="polite" aria-hidden="true">
+    <div class="panel">
+      <div class="pl-spinner"></div>
+      <div class="text">
+        <strong>Loading TLS Summary&hellip;</strong>
+        <small>Scanning saved results</small>
+      </div>
+    </div>
+  </div>
 </body>
 </html>

--- a/quicklook/app/templates/gallery.html
+++ b/quicklook/app/templates/gallery.html
@@ -134,6 +134,21 @@
       background: var(--primary); color: #fff; border-color: var(--primary); font-weight: 600;
     }
     .pagination .disabled { opacity: 0.4; pointer-events: none; }
+    .per-page-label {
+      display: inline-flex; align-items: center; gap: 6px;
+      margin-left: 12px; font-size: 0.82rem; color: var(--text-sec);
+    }
+    /* Neutralise the .pagination span button styles for our inline label. */
+    .pagination .per-page-text {
+      display: inline; min-width: 0; height: auto; padding: 0;
+      border: none; background: transparent; color: var(--text-sec);
+      font-size: 0.82rem;
+    }
+    .per-page-select {
+      padding: 5px 8px; border: 1px solid var(--input-border); border-radius: 5px;
+      font-size: 0.85rem; background: var(--input-bg); color: var(--text); cursor: pointer;
+    }
+    .per-page-select:focus { outline: none; border-color: var(--primary); }
 
     /* Modal */
     .modal {
@@ -163,6 +178,29 @@
       border-radius: 50%; animation: spin 0.8s linear infinite; flex-shrink: 0;
     }
     @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* Shared full-page loading overlay (matches index / tls_summary) */
+    .page-loading {
+      position: fixed; inset: 0; background: rgba(0,0,0,0.45);
+      display: none; align-items: center; justify-content: center;
+      z-index: 2000; backdrop-filter: blur(2px);
+    }
+    .page-loading.show { display: flex; }
+    .page-loading .panel {
+      background: var(--card-bg); border: 1px solid var(--border);
+      border-radius: 10px; padding: 18px 22px;
+      display: flex; align-items: center; gap: 14px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.25);
+      min-width: 280px; max-width: 92%;
+    }
+    .page-loading .pl-spinner {
+      width: 22px; height: 22px; flex-shrink: 0;
+      border: 3px solid var(--primary); border-top-color: transparent;
+      border-radius: 50%; animation: spin 0.8s linear infinite;
+    }
+    .page-loading .text { display: flex; flex-direction: column; gap: 2px; }
+    .page-loading .text strong { font-size: 0.95rem; }
+    .page-loading .text small { font-size: 0.78rem; color: var(--text-sec); }
     .running-banner a { color: var(--primary); font-weight: 600; text-decoration: none; }
     .running-banner a:hover { text-decoration: underline; }
     .running-banner .job-list { display: flex; gap: 8px; flex-wrap: wrap; }
@@ -189,6 +227,7 @@
     <div class="top-bar-left">
       <a href="{{ url_for('index') }}" class="btn btn-primary">&larr; Back</a>
       <a href="{{ url_for('compare') }}" class="btn btn-outline">Compare</a>
+      <a href="{{ url_for('tls_summary') }}" class="btn btn-outline" id="summaryLink">Summary</a>
       <button class="theme-toggle" id="themeToggle" title="Toggle dark mode">&#9790;</button>
     </div>
     <div class="controls">
@@ -241,7 +280,7 @@
   {% if total_pages > 1 %}
   <div class="pagination">
     {% if page > 1 %}
-      <a href="{{ url_for('gallery', search=search_name, sort=sort_by, page=page-1) }}">&laquo; Prev</a>
+      <a href="{{ url_for('gallery', search=search_name, sort=sort_by, page=page-1, per_page=per_page) }}">&laquo; Prev</a>
     {% else %}
       <span class="disabled">&laquo; Prev</span>
     {% endif %}
@@ -250,17 +289,26 @@
       {% if p == page %}
         <span class="current">{{ p }}</span>
       {% elif p <= 3 or p > total_pages - 3 or (p >= page - 2 and p <= page + 2) %}
-        <a href="{{ url_for('gallery', search=search_name, sort=sort_by, page=p) }}">{{ p }}</a>
+        <a href="{{ url_for('gallery', search=search_name, sort=sort_by, page=p, per_page=per_page) }}">{{ p }}</a>
       {% elif p == 4 or p == total_pages - 3 %}
         <span>&hellip;</span>
       {% endif %}
     {% endfor %}
 
     {% if page < total_pages %}
-      <a href="{{ url_for('gallery', search=search_name, sort=sort_by, page=page+1) }}">Next &raquo;</a>
+      <a href="{{ url_for('gallery', search=search_name, sort=sort_by, page=page+1, per_page=per_page) }}">Next &raquo;</a>
     {% else %}
       <span class="disabled">Next &raquo;</span>
     {% endif %}
+
+    <label class="per-page-label" for="perPageSelect" title="Number of images per page">
+      <span class="per-page-text">per page</span>
+      <select id="perPageSelect" class="per-page-select">
+        {% for n in per_page_choices %}
+        <option value="{{ n }}" {% if n == per_page %}selected{% endif %}>{{ n }}</option>
+        {% endfor %}
+      </select>
+    </label>
   </div>
   {% endif %}
 
@@ -454,6 +502,42 @@
     }
     pollRunningJobs();
     setInterval(pollRunningJobs, 5000);
+
+    /* Per-page selector: reload the gallery preserving search/sort and
+       resetting to page 1 when the user changes the page size. */
+    (function () {
+      const sel = document.getElementById('perPageSelect');
+      if (!sel) return;
+      sel.addEventListener('change', () => {
+        const url = new URL(window.location.href);
+        url.searchParams.set('per_page', sel.value);
+        url.searchParams.set('page', '1');
+        window.location.href = url.toString();
+      });
+    })();
+
+    /* Show the shared loading overlay when navigating to the (potentially
+       slow) TLS Summary page. The overlay markup is parsed after this
+       script, so we look it up lazily inside the click handler. */
+    (function () {
+      const link = document.getElementById('summaryLink');
+      if (!link) return;
+      link.addEventListener('click', (e) => {
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return;
+        const overlay = document.getElementById('pageLoading');
+        if (overlay) overlay.classList.add('show');
+      });
+    })();
   </script>
+
+  <div class="page-loading" id="pageLoading" role="status" aria-live="polite" aria-hidden="true">
+    <div class="panel">
+      <div class="pl-spinner"></div>
+      <div class="text">
+        <strong>Loading TLS Summary&hellip;</strong>
+        <small>Scanning saved results</small>
+      </div>
+    </div>
+  </div>
 </body>
 </html>

--- a/quicklook/app/templates/index.html
+++ b/quicklook/app/templates/index.html
@@ -197,6 +197,29 @@
       border-radius: 50%; animation: spin 0.8s linear infinite; flex-shrink: 0;
     }
     @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* Full-page loading overlay (shown on heavy navigations like TLS Summary) */
+    .page-loading {
+      position: fixed; inset: 0; background: rgba(0,0,0,0.45);
+      display: none; align-items: center; justify-content: center;
+      z-index: 2000; backdrop-filter: blur(2px);
+    }
+    .page-loading.show { display: flex; }
+    .page-loading .panel {
+      background: var(--card-bg); border: 1px solid var(--border);
+      border-radius: 10px; padding: 18px 22px;
+      display: flex; align-items: center; gap: 14px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.25);
+      min-width: 280px; max-width: 92%;
+    }
+    .page-loading .pl-spinner {
+      width: 22px; height: 22px; flex-shrink: 0;
+      border: 3px solid var(--primary); border-top-color: transparent;
+      border-radius: 50%; animation: spin 0.8s linear infinite;
+    }
+    .page-loading .text { display: flex; flex-direction: column; gap: 2px; }
+    .page-loading .text strong { font-size: 0.95rem; }
+    .page-loading .text small { font-size: 0.78rem; color: var(--text-sec); }
     .status-bar .btn { margin-left: auto; }
 
     /* --- Progress --- */
@@ -654,6 +677,7 @@
 <div class="footer-nav">
   <a href="{{ url_for('gallery') }}" class="btn btn-outline">Browse All Results</a>
   <a href="{{ url_for('compare') }}" class="btn btn-outline">Compare Results</a>
+  <a href="{{ url_for('tls_summary') }}" class="btn btn-outline" id="tlsSummaryLink">TLS Summary</a>
 </div>
 
 <script>
@@ -1497,6 +1521,34 @@ if ('Notification' in window && Notification.permission === 'default') {
 })();
 
 setInterval(refreshQueue, 5000);
+
+/* Show a full-page loading overlay when the user clicks "TLS Summary".
+   /tls-summary walks every *_tls.h5 in the chosen folder and can take a
+   few seconds, so we give immediate visual feedback. */
+(function () {
+  const link = document.getElementById('tlsSummaryLink');
+  if (!link) return;
+  link.addEventListener('click', (e) => {
+    // Ignore modifier-click / middle-click (new-tab) so we don't flash
+    // the overlay on the current page when the user opens it elsewhere.
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return;
+    // Look up the overlay lazily — it sits after this <script> in the
+    // source, so it doesn't exist when the IIFE first runs.
+    const overlay = document.getElementById('pageLoading');
+    if (overlay) overlay.classList.add('show');
+  });
+})();
 </script>
+
+<div class="page-loading" id="pageLoading" role="status" aria-live="polite" aria-hidden="true">
+  <div class="panel">
+    <div class="pl-spinner"></div>
+    <div class="text">
+      <strong>Loading TLS Summary&hellip;</strong>
+      <small>Scanning saved results</small>
+    </div>
+  </div>
+</div>
+
 </body>
 </html>

--- a/quicklook/app/templates/tls_summary.html
+++ b/quicklook/app/templates/tls_summary.html
@@ -1,0 +1,787 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TLS Results Summary</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><circle cx='8' cy='8' r='6' fill='%234a6cf7'/><circle cx='8' cy='8' r='2' fill='white'/></svg>">
+  <style>
+    :root {
+      --bg: #f5f6fa; --card-bg: #fff; --text: #1a1a2e; --text-sec: #666;
+      --border: #e0e0e0; --border-light: #f0f0f0; --input-bg: #fafafa;
+      --input-border: #ccc; --hover-bg: #eef1ff;
+      --primary: #4a6cf7; --primary-hover: #3451d1;
+      --row-alt: #f9fafe;
+      --thead-bg: #eef1ff;
+      --pill-bg: #e0e7ff; --pill-fg: #1d4ed8;
+    }
+    [data-theme="dark"] {
+      --bg: #0f0f1a; --card-bg: #1a1a2e; --text: #e0e0e0; --text-sec: #999;
+      --border: #2a2a3e; --border-light: #222236; --input-bg: #252538;
+      --input-border: #3a3a4e; --hover-bg: #1f2342;
+      --primary: #5b7cf9; --primary-hover: #7b96ff;
+      --row-alt: #14142a;
+      --thead-bg: #1f2342;
+      --pill-bg: #1e3a5f; --pill-fg: #93c5fd;
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      max-width: 1400px; margin: 0 auto; padding: 24px 20px;
+      color: var(--text); background: var(--bg); line-height: 1.5;
+      transition: background-color 0.3s, color 0.3s;
+    }
+    a { color: var(--primary); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    h1 { text-align: center; font-size: 1.5rem; margin: 0 0 4px; }
+    .subtitle { text-align: center; color: var(--text-sec); font-size: 0.88rem; margin-bottom: 18px; }
+
+    .top-bar {
+      display: flex; align-items: center; gap: 10px;
+      flex-wrap: wrap; margin-bottom: 14px;
+    }
+    .btn {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 8px 14px; font-size: 0.88rem; font-weight: 600; border: none;
+      border-radius: 6px; cursor: pointer; text-decoration: none;
+      transition: background-color 0.2s, color 0.2s;
+    }
+    .btn-outline { background: transparent; color: var(--primary); border: 1px solid var(--primary); }
+    .btn-outline:hover { background: var(--primary); color: #fff; }
+    .theme-toggle {
+      background: var(--card-bg); border: 1px solid var(--border); border-radius: 8px;
+      padding: 6px 10px; cursor: pointer; font-size: 1rem; line-height: 1;
+      color: var(--text); transition: background-color 0.2s;
+    }
+    .theme-toggle:hover { background: var(--hover-bg); }
+
+    .controls { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-left: auto; }
+    .search {
+      padding: 7px 12px; border: 1px solid var(--input-border); border-radius: 6px;
+      font-size: 0.9rem; min-width: 240px; background: var(--input-bg); color: var(--text);
+    }
+    .search:focus { outline: none; border-color: var(--primary); }
+    .count {
+      font-size: 0.82rem; color: var(--text-sec); white-space: nowrap;
+    }
+
+    .table-wrap {
+      background: var(--card-bg); border: 1px solid var(--border); border-radius: 10px;
+      overflow: auto; max-height: 78vh;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+    }
+    table { width: 100%; border-collapse: collapse; font-size: 0.85rem; min-width: 1500px; }
+    thead { position: sticky; top: 0; z-index: 1; }
+    thead th {
+      background: var(--thead-bg); color: var(--text);
+      font-weight: 700; font-size: 0.78rem; text-transform: uppercase;
+      letter-spacing: 0.3px;
+      padding: 10px 12px; text-align: left; cursor: pointer; user-select: none;
+      border-bottom: 1px solid var(--border);
+      white-space: nowrap;
+    }
+    thead th .arrow { color: var(--text-sec); margin-left: 4px; font-size: 0.75rem; opacity: 0.4; }
+    thead th.sort-asc  .arrow::before { content: "\25B2"; opacity: 1; color: var(--primary); }
+    thead th.sort-desc .arrow::before { content: "\25BC"; opacity: 1; color: var(--primary); }
+    thead th .arrow::before { content: "\25C7"; }
+
+    tbody td {
+      padding: 8px 12px; border-bottom: 1px solid var(--border-light);
+      vertical-align: middle; white-space: nowrap;
+    }
+    tbody tr:nth-child(even) { background: var(--row-alt); }
+    tbody tr:hover { background: var(--hover-bg); }
+    .num { font-variant-numeric: tabular-nums; text-align: right; }
+    .target { font-weight: 600; }
+    .pill {
+      display: inline-block; padding: 2px 8px; border-radius: 999px;
+      font-size: 0.72rem; font-weight: 700;
+      background: var(--pill-bg); color: var(--pill-fg);
+      text-transform: lowercase;
+    }
+    .muted { color: var(--text-sec); }
+    .actions { display: flex; gap: 6px; }
+    .actions a { font-size: 0.78rem; color: var(--primary); }
+    .empty {
+      padding: 60px 20px; text-align: center; color: var(--text-sec);
+      font-size: 0.95rem;
+    }
+    .skipped {
+      margin-top: 12px; font-size: 0.78rem; color: var(--text-sec);
+    }
+    .skipped details summary { cursor: pointer; }
+    /* Directory chooser */
+    .dir-bar {
+      display: flex; flex-direction: column; gap: 6px;
+      margin-bottom: 14px;
+    }
+    .dir-form {
+      display: flex; gap: 8px; align-items: center; flex-wrap: wrap;
+      background: var(--card-bg); border: 1px solid var(--border);
+      border-radius: 8px; padding: 8px 12px;
+    }
+    .dir-form label {
+      font-size: 0.82rem; color: var(--text-sec); white-space: nowrap;
+    }
+    .dir-form input[type="text"] {
+      flex: 1; min-width: 280px;
+      padding: 7px 12px; border: 1px solid var(--input-border);
+      border-radius: 6px; font-size: 0.85rem;
+      background: var(--input-bg); color: var(--text);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+    .dir-form input[type="text"]:focus { outline: none; border-color: var(--primary); }
+    .dir-form .btn-sm { padding: 5px 12px; font-size: 0.8rem; }
+    .dir-error {
+      padding: 8px 12px; background: #fef2f2; color: #b91c1c;
+      border: 1px solid #fecaca; border-radius: 6px; font-size: 0.85rem;
+    }
+    [data-theme="dark"] .dir-error {
+      background: #7f1d1d; color: #fca5a5; border-color: #b91c1c;
+    }
+    /* Page-loading overlay (shown after submitting a directory change) */
+    .page-loading {
+      position: fixed; inset: 0; background: rgba(0,0,0,0.45);
+      display: none; align-items: center; justify-content: center;
+      z-index: 2000; backdrop-filter: blur(2px);
+    }
+    .page-loading.show { display: flex; }
+    .page-loading .panel {
+      background: var(--card-bg); border: 1px solid var(--border);
+      border-radius: 10px; padding: 18px 22px;
+      display: flex; align-items: center; gap: 14px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.25);
+      min-width: 280px; max-width: 92%;
+    }
+    .page-loading .pl-spinner {
+      width: 22px; height: 22px; flex-shrink: 0;
+      border: 3px solid var(--primary); border-top-color: transparent;
+      border-radius: 50%; animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .page-loading .text { display: flex; flex-direction: column; gap: 2px; }
+    .page-loading .text strong { font-size: 0.95rem; }
+    .page-loading .text small {
+      font-size: 0.78rem; color: var(--text-sec);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      word-break: break-all;
+    }
+
+    /* Browse modal */
+    .modal-backdrop {
+      position: fixed; inset: 0; background: rgba(0,0,0,0.5);
+      display: none; align-items: center; justify-content: center; z-index: 1000;
+    }
+    .modal-backdrop.open { display: flex; }
+    .modal {
+      background: var(--card-bg); border: 1px solid var(--border);
+      border-radius: 10px; width: 92%; max-width: 720px; max-height: 80vh;
+      display: flex; flex-direction: column;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+    }
+    .modal-header {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 12px 16px; border-bottom: 1px solid var(--border);
+    }
+    .modal-header h2 { margin: 0; font-size: 1rem; }
+    .modal-close {
+      background: none; border: none; cursor: pointer;
+      font-size: 1.4rem; color: var(--text-sec); line-height: 1; padding: 0 4px;
+    }
+    .modal-close:hover { color: var(--text); }
+    .modal-body { padding: 12px 16px; overflow: auto; flex: 1; }
+    .modal-footer {
+      display: flex; gap: 8px; justify-content: flex-end;
+      padding: 12px 16px; border-top: 1px solid var(--border);
+    }
+    .breadcrumb {
+      display: flex; flex-wrap: wrap; gap: 4px; align-items: center;
+      font-size: 0.82rem; margin-bottom: 10px;
+    }
+    .breadcrumb a {
+      color: var(--primary); cursor: pointer; padding: 2px 4px; border-radius: 3px;
+    }
+    .breadcrumb a:hover { background: var(--hover-bg); text-decoration: underline; }
+    .breadcrumb .sep { color: var(--text-sec); }
+    .modal-current {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.78rem; color: var(--text-sec);
+      padding: 6px 10px; background: var(--input-bg);
+      border-radius: 4px; margin-bottom: 10px; word-break: break-all;
+    }
+    .modal-current .badge {
+      background: var(--pill-bg); color: var(--pill-fg);
+      font-size: 0.7rem; padding: 2px 6px; border-radius: 10px;
+      font-weight: 700; margin-left: 8px; text-transform: uppercase;
+    }
+    .dir-list { display: flex; flex-direction: column; gap: 2px; }
+    .dir-row {
+      display: flex; align-items: center; gap: 8px;
+      padding: 7px 10px; border-radius: 6px; cursor: pointer;
+      transition: background-color 0.1s;
+    }
+    .dir-row:hover { background: var(--hover-bg); }
+    .dir-row .icon { color: var(--text-sec); }
+    .dir-row .name {
+      flex: 1;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.85rem; overflow: hidden; text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .dir-row .tls-badge {
+      background: var(--pill-bg); color: var(--pill-fg);
+      font-size: 0.68rem; padding: 1px 6px; border-radius: 10px; font-weight: 700;
+      text-transform: uppercase;
+    }
+    .dir-row .chev { color: var(--text-sec); font-size: 1rem; }
+    .modal-empty {
+      padding: 20px; text-align: center; color: var(--text-sec); font-size: 0.85rem;
+    }
+    .modal-error:empty { display: none; }
+    .modal-error {
+      margin-bottom: 10px; padding: 8px 12px;
+      background: #fef2f2; color: #b91c1c;
+      border: 1px solid #fecaca; border-radius: 6px; font-size: 0.82rem;
+    }
+    [data-theme="dark"] .modal-error {
+      background: #7f1d1d; color: #fca5a5; border-color: #b91c1c;
+    }
+    /* "Only folders with TLS files" filter */
+    .filter-row {
+      display: flex; align-items: center; gap: 6px;
+      font-size: 0.82rem; color: var(--text-sec);
+      margin-bottom: 8px; user-select: none;
+    }
+    .filter-row label { cursor: pointer; display: flex; align-items: center; gap: 6px; }
+    .dir-list.tls-only .dir-row:not(.has-tls) { display: none; }
+    .dir-list.tls-only .dir-row.has-tls .tls-badge { display: none; } /* redundant when filtered */
+
+    .ext-path {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.75rem; color: var(--text-sec);
+      max-width: 360px; overflow: hidden; text-overflow: ellipsis;
+      display: inline-block; vertical-align: middle;
+    }
+
+    @media (max-width: 800px) {
+      .controls { width: 100%; }
+      .search { min-width: 0; flex: 1; }
+    }
+  </style>
+</head>
+<body>
+
+<div class="top-bar">
+  <a href="{{ url_for('index') }}" class="btn btn-outline">&larr; Back</a>
+  <a href="{{ url_for('gallery') }}" class="btn btn-outline">Gallery</a>
+  <a href="{{ url_for('compare') }}" class="btn btn-outline">Compare</a>
+  <div class="controls">
+    <input type="search" id="search" class="search" placeholder="Filter by target, pipeline, anything..." autofocus>
+    <span class="count" id="count">{{ total }} result{{ '' if total == 1 else 's' }}</span>
+    <button class="theme-toggle" id="themeToggle" title="Toggle dark mode">&#9790;</button>
+  </div>
+</div>
+
+<div class="dir-bar">
+  <form method="get" action="{{ url_for('tls_summary') }}" class="dir-form" id="dirForm"
+        data-current-dir="{{ current_dir }}"
+        data-is-default="{{ 'true' if is_default_dir else 'false' }}"
+        data-has-dir-param="{{ 'true' if request.args.get('dir') else 'false' }}">
+    <label for="dirInput">TLS directory:</label>
+    <input type="text" id="dirInput" name="dir" value="{{ current_dir }}"
+           list="recent-dirs" spellcheck="false" autocomplete="off"
+           placeholder="absolute path to *_tls.h5 directory">
+    <datalist id="recent-dirs"></datalist>
+    <button type="button" class="btn btn-outline btn-sm" id="browseBtn" title="Browse a tree of directories on this machine">Browse&hellip;</button>
+    <button type="submit" class="btn btn-outline btn-sm">Load</button>
+    {% if not is_default_dir %}
+    <a href="{{ url_for('tls_summary') }}" class="btn btn-outline btn-sm" title="Reset to the app's default outputs folder">Reset</a>
+    {% endif %}
+  </form>
+  {% if dir_error %}
+  <div class="dir-error">&#9888; {{ dir_error }} &mdash; showing default folder.</div>
+  {% endif %}
+</div>
+
+<h1>TLS Results Summary</h1>
+<p class="subtitle">All saved TLS HDF5 outputs &mdash; click a column to sort, type to filter.</p>
+
+{% if rows %}
+<div class="table-wrap">
+  <table id="tlsTable">
+    <thead>
+      <tr>
+        <th data-key="target" data-type="str">Target <span class="arrow"></span></th>
+        <th data-key="pipeline" data-type="str">Pipeline <span class="arrow"></span></th>
+        <th data-key="exptime" data-type="num">Exp (s) <span class="arrow"></span></th>
+        <th data-key="sector" data-type="num">Sector <span class="arrow"></span></th>
+        <th data-key="Porb" data-type="num">Porb [d] <span class="arrow"></span></th>
+        <th data-key="duration_hr" data-type="num">Dur [hr] <span class="arrow"></span></th>
+        <th data-key="rp_rs" data-type="num">Rp/Rs <span class="arrow"></span></th>
+        <th data-key="depth_ppt" data-type="num">Depth [ppt] <span class="arrow"></span></th>
+        <th data-key="SDE" data-type="num">SDE <span class="arrow"></span></th>
+        <th data-key="snr" data-type="num">SNR <span class="arrow"></span></th>
+        <th data-key="FAP" data-type="num">FAP <span class="arrow"></span></th>
+        <th data-key="odd_even" data-type="num">Odd-even &Delta; <span class="arrow"></span></th>
+        <th data-key="n_tr" data-type="num">N_tr <span class="arrow"></span></th>
+        <th data-key="Prot_gls" data-type="num">Prot [d] <span class="arrow"></span></th>
+        <th data-key="power_gls" data-type="num">GLS power <span class="arrow"></span></th>
+        <th data-key="toi" data-type="num">TOI <span class="arrow"></span></th>
+        <th data-key="tic" data-type="num">TIC <span class="arrow"></span></th>
+        <th>Files</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for r in rows %}
+      <tr>
+        <td class="target" data-target="{{ r.stem }}">
+          {% if r.png %}<a href="{{ r.png }}" target="_blank">{{ r.stem }}</a>{% else %}{{ r.stem }}{% endif %}
+        </td>
+        <td>{% if r.pipeline %}<span class="pill">{{ r.pipeline }}</span>{% else %}<span class="muted">&mdash;</span>{% endif %}</td>
+        <td class="num" data-v="{{ r.exptime if r.exptime is not none else '' }}">
+          {% if r.exptime is not none %}{{ "%.0f"|format(r.exptime) }}{% endif %}
+        </td>
+        <td class="num" data-v="{{ r.sector if r.sector is not none else '' }}">
+          {% if r.sector is not none %}{{ r.sector }}{% endif %}
+        </td>
+        <td class="num" data-v="{{ r.Porb if r.Porb is not none else '' }}">
+          {% if r.Porb is not none %}{{ "%.4f"|format(r.Porb) }}{% endif %}
+        </td>
+        <td class="num" data-v="{{ r.duration_hr if r.duration_hr is not none else '' }}">
+          {% if r.duration_hr is not none %}{{ "%.2f"|format(r.duration_hr) }}{% endif %}
+        </td>
+        <td class="num" data-v="{{ r.rp_rs if r.rp_rs is not none else '' }}">
+          {% if r.rp_rs is not none %}{{ "%.4f"|format(r.rp_rs) }}{% endif %}
+        </td>
+        <td class="num" data-v="{{ r.depth_ppt if r.depth_ppt is not none else '' }}">
+          {% if r.depth_ppt is not none %}{{ "%.2f"|format(r.depth_ppt) }}{% endif %}
+        </td>
+        <td class="num" data-v="{{ r.SDE if r.SDE is not none else '' }}">
+          {% if r.SDE is not none %}{{ "%.2f"|format(r.SDE) }}{% endif %}
+        </td>
+        <td class="num" data-v="{{ r.snr if r.snr is not none else '' }}">
+          {% if r.snr is not none %}{{ "%.2f"|format(r.snr) }}{% endif %}
+        </td>
+        <td class="num" data-v="{{ r.FAP if r.FAP is not none else '' }}">
+          {% if r.FAP is not none %}{{ "%.2e"|format(r.FAP) }}{% endif %}
+        </td>
+        <td class="num" data-v="{{ r.odd_even if r.odd_even is not none else '' }}">
+          {% if r.odd_even is not none %}{{ "%.2f"|format(r.odd_even) }}{% endif %}
+        </td>
+        <td class="num" data-v="{{ r.n_tr if r.n_tr is not none else '' }}">
+          {% if r.n_tr is not none %}{{ r.n_tr }}{% endif %}
+        </td>
+        <td class="num" data-v="{{ r.Prot_gls if r.Prot_gls is not none else '' }}">
+          {% if r.Prot_gls is not none %}{{ "%.3f"|format(r.Prot_gls) }}{% endif %}
+        </td>
+        <td class="num" data-v="{{ r.power_gls if r.power_gls is not none else '' }}">
+          {% if r.power_gls is not none %}{{ "%.4f"|format(r.power_gls) }}{% endif %}
+        </td>
+        <td class="num" data-v="{{ r.toi if r.toi is not none else '' }}">{{ r.toi if r.toi is not none else '' }}</td>
+        <td class="num" data-v="{{ r.tic if r.tic is not none else '' }}">{{ r.tic if r.tic is not none else '' }}</td>
+        <td class="actions">
+          {% if r.external %}
+            <span class="ext-path" title="{{ r.disk_path }}">{{ r.disk_path }}</span>
+          {% else %}
+            {% if r.png %}<a href="{{ r.png }}" target="_blank">PNG</a>{% endif %}
+            {% if r.h5 %}<a href="{{ r.h5 }}" download>H5</a>{% endif %}
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% else %}
+<div class="empty">
+  No TLS results have been saved yet. Run a QuickLook with <em>Save outputs</em> enabled and the resulting <code>*_tls.h5</code> files will appear here.
+</div>
+{% endif %}
+
+{% if skipped %}
+<div class="skipped">
+  <details>
+    <summary>{{ skipped|length }} file{{ '' if skipped|length == 1 else 's' }} could not be parsed</summary>
+    <ul>
+      {% for s in skipped %}
+      <li><code>{{ s.name }}</code> &mdash; {{ s.error }}</li>
+      {% endfor %}
+    </ul>
+  </details>
+</div>
+{% endif %}
+
+<script>
+/* =========================================================================
+   Persist the selected TLS directory across page navigations.
+   - Save the *current* dir to localStorage whenever the page is rendered
+     with a valid non-default dir.
+   - On a clean visit (no ?dir= in URL), rehydrate from storage by
+     redirecting to /tls-summary?dir=<saved> exactly once.
+   - The "Reset" link explicitly clears the saved value (handler below).
+   ========================================================================= */
+(function persistSelectedDir() {
+  const KEY = 'tls-summary-current-dir';
+  const form = document.getElementById('dirForm');
+  if (!form) return;
+  const currentDir = form.dataset.currentDir || '';
+  const isDefault = form.dataset.isDefault === 'true';
+  const urlHasDir = form.dataset.hasDirParam === 'true';
+
+  if (!urlHasDir) {
+    // Fresh page load (no ?dir=); rehydrate if we have a saved one.
+    let saved = null;
+    try { saved = localStorage.getItem(KEY); } catch (e) { saved = null; }
+    if (saved && saved !== currentDir) {
+      window.location.replace('/tls-summary?dir=' + encodeURIComponent(saved));
+      return; // The new navigation will re-run this script.
+    }
+  } else if (!isDefault && currentDir) {
+    // Server confirmed a custom dir is loaded — remember it.
+    try { localStorage.setItem(KEY, currentDir); } catch (e) {}
+  }
+  // Note: when URL had ?dir= but server fell back to default (bad path),
+  // we intentionally leave the previously-saved value untouched.
+})();
+
+/* Theme toggle (matches index/gallery) */
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-theme', theme);
+  document.getElementById('themeToggle').textContent = theme === 'dark' ? '☀' : '☾';
+  localStorage.setItem('ql-theme', theme);
+}
+(function init() {
+  const saved = localStorage.getItem('ql-theme');
+  if (saved) { applyTheme(saved); return; }
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) applyTheme('dark');
+})();
+document.getElementById('themeToggle').addEventListener('click', () => {
+  const cur = document.documentElement.getAttribute('data-theme');
+  applyTheme(cur === 'dark' ? 'light' : 'dark');
+});
+
+/* Directory input — persist recently-used paths in localStorage */
+const DIR_HISTORY_KEY = 'tls-summary-dir-history';
+const DIR_HISTORY_MAX = 10;
+const dirInput = document.getElementById('dirInput');
+const dirDatalist = document.getElementById('recent-dirs');
+const dirForm = document.getElementById('dirForm');
+
+function loadDirHistory() {
+  try { return JSON.parse(localStorage.getItem(DIR_HISTORY_KEY) || '[]'); }
+  catch (e) { return []; }
+}
+function saveDirHistory(list) {
+  localStorage.setItem(DIR_HISTORY_KEY, JSON.stringify(list.slice(0, DIR_HISTORY_MAX)));
+}
+function renderDirHistory() {
+  const list = loadDirHistory();
+  if (dirDatalist) {
+    dirDatalist.innerHTML = list.map(p => {
+      const v = p.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+      return '<option value="' + v + '">';
+    }).join('');
+  }
+}
+if (dirForm) {
+  dirForm.addEventListener('submit', () => {
+    const v = dirInput.value.trim();
+    if (v) {
+      const list = loadDirHistory().filter(p => p !== v);
+      list.unshift(v);
+      saveDirHistory(list);
+    }
+    // Show loading overlay; the form submission triggers a full-page
+    // navigation, so this stays visible until the new page renders.
+    const overlay = document.getElementById('pageLoading');
+    const overlayPath = document.getElementById('pageLoadingPath');
+    if (overlay) {
+      if (overlayPath) overlayPath.textContent = v || '(default folder)';
+      overlay.classList.add('show');
+      overlay.setAttribute('aria-hidden', 'false');
+    }
+  });
+}
+renderDirHistory();
+
+/* Also show the loading overlay when the "Reset" link is clicked, and
+   clear the persisted dir so we don't immediately rehydrate from it. */
+document.querySelectorAll('.dir-form a[href]').forEach(a => {
+  a.addEventListener('click', () => {
+    try { localStorage.removeItem('tls-summary-current-dir'); } catch (e) {}
+    const overlay = document.getElementById('pageLoading');
+    const overlayPath = document.getElementById('pageLoadingPath');
+    if (overlay) {
+      if (overlayPath) overlayPath.textContent = '(default folder)';
+      overlay.classList.add('show');
+      overlay.setAttribute('aria-hidden', 'false');
+    }
+  });
+});
+
+/* Search (live filter across all visible columns) */
+const table = document.getElementById('tlsTable');
+const search = document.getElementById('search');
+const countEl = document.getElementById('count');
+const rows = table ? Array.from(table.tBodies[0].rows) : [];
+
+function applySearch() {
+  if (!table) return;
+  const q = search.value.trim().toLowerCase();
+  let visible = 0;
+  for (const row of rows) {
+    const text = row.textContent.toLowerCase();
+    const match = q === '' || text.includes(q);
+    row.style.display = match ? '' : 'none';
+    if (match) visible++;
+  }
+  countEl.textContent = visible + ' / ' + rows.length + ' results';
+}
+if (search) search.addEventListener('input', applySearch);
+
+/* Sort by column (toggle asc/desc, numeric vs string aware) */
+let activeTh = null;
+let activeDir = 1; // 1 = asc, -1 = desc
+
+function cellValue(row, idx, type) {
+  const td = row.cells[idx];
+  if (!td) return type === 'num' ? NaN : '';
+  if (type === 'num') {
+    const v = td.dataset.v ?? td.textContent.trim();
+    if (v === '' || v === null || v === undefined) return NaN;
+    const n = parseFloat(v);
+    return isNaN(n) ? NaN : n;
+  }
+  return td.textContent.trim().toLowerCase();
+}
+
+if (table) {
+  const ths = Array.from(table.tHead.rows[0].cells);
+  ths.forEach((th, idx) => {
+    if (!th.dataset.key) return; // "Files" column has no key
+    th.addEventListener('click', () => {
+      const type = th.dataset.type;
+      if (activeTh === th) {
+        activeDir = -activeDir;
+      } else {
+        if (activeTh) activeTh.classList.remove('sort-asc', 'sort-desc');
+        activeTh = th;
+        activeDir = (type === 'num') ? -1 : 1; // numeric defaults to desc (e.g. high SDE first)
+      }
+      th.classList.toggle('sort-asc', activeDir === 1);
+      th.classList.toggle('sort-desc', activeDir === -1);
+
+      const sorted = rows.slice().sort((a, b) => {
+        const va = cellValue(a, idx, type);
+        const vb = cellValue(b, idx, type);
+        const aMiss = (type === 'num') ? isNaN(va) : va === '';
+        const bMiss = (type === 'num') ? isNaN(vb) : vb === '';
+        if (aMiss && bMiss) return 0;
+        if (aMiss) return 1;
+        if (bMiss) return -1;
+        if (va < vb) return -1 * activeDir;
+        if (va > vb) return  1 * activeDir;
+        return 0;
+      });
+      const tbody = table.tBodies[0];
+      sorted.forEach(r => tbody.appendChild(r));
+    });
+  });
+}
+</script>
+
+<div class="page-loading" id="pageLoading" role="status" aria-live="polite" aria-hidden="true">
+  <div class="panel">
+    <div class="pl-spinner"></div>
+    <div class="text">
+      <strong>Loading TLS results…</strong>
+      <small id="pageLoadingPath"></small>
+    </div>
+  </div>
+</div>
+
+<div class="modal-backdrop" id="browseModal" role="dialog" aria-modal="true" aria-labelledby="browseTitle">
+  <div class="modal">
+    <div class="modal-header">
+      <h2 id="browseTitle">Browse for TLS results directory</h2>
+      <button type="button" class="modal-close" id="browseClose" title="Close">&times;</button>
+    </div>
+    <div class="modal-body">
+      <div class="breadcrumb" id="browseBreadcrumb"></div>
+      <div class="modal-current" id="browseCurrent"></div>
+      <div class="modal-error" id="browseError"></div>
+      <div class="filter-row">
+        <label>
+          <input type="checkbox" id="tlsOnlyToggle">
+          Only show folders with TLS files
+        </label>
+      </div>
+      <div class="dir-list" id="browseList"></div>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="btn btn-outline btn-sm" id="browseCancel">Cancel</button>
+      <button type="button" class="btn btn-outline btn-sm" id="browseSelect">Select this directory</button>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ============================================================
+   Browse directory tree (modal). Hits /list-dirs server-side;
+   scoped to ALLOWED_BROWSE_ROOTS (default $HOME).
+   ============================================================ */
+(function () {
+  const modal = document.getElementById('browseModal');
+  const browseBtn = document.getElementById('browseBtn');
+  const closeBtn = document.getElementById('browseClose');
+  const cancelBtn = document.getElementById('browseCancel');
+  const selectBtn = document.getElementById('browseSelect');
+  const breadcrumb = document.getElementById('browseBreadcrumb');
+  const currentEl = document.getElementById('browseCurrent');
+  const errorEl = document.getElementById('browseError');
+  const listEl = document.getElementById('browseList');
+  const dirInputEl = document.getElementById('dirInput');
+  const dirFormEl = document.getElementById('dirForm');
+
+  if (!modal || !browseBtn) return;
+
+  let currentPath = null;
+
+  /* Persist the "Only TLS folders" filter across sessions. */
+  const TLS_ONLY_KEY = 'tls-summary-browse-tls-only';
+  const tlsOnlyToggle = document.getElementById('tlsOnlyToggle');
+  function applyTlsOnly() {
+    if (!listEl || !tlsOnlyToggle) return;
+    listEl.classList.toggle('tls-only', tlsOnlyToggle.checked);
+  }
+  if (tlsOnlyToggle && listEl) {
+    let saved = false;
+    try { saved = localStorage.getItem(TLS_ONLY_KEY) === '1'; } catch (e) {}
+    tlsOnlyToggle.checked = saved;
+    applyTlsOnly();
+    tlsOnlyToggle.addEventListener('change', () => {
+      try {
+        if (tlsOnlyToggle.checked) localStorage.setItem(TLS_ONLY_KEY, '1');
+        else localStorage.removeItem(TLS_ONLY_KEY);
+      } catch (e) {}
+      applyTlsOnly();
+    });
+  }
+
+  async function loadDirs(path) {
+    errorEl.textContent = '';
+    listEl.innerHTML = '<div class="modal-empty">Loading…</div>';
+    const url = '/list-dirs' + (path ? '?path=' + encodeURIComponent(path) : '');
+    let data;
+    try {
+      const res = await fetch(url);
+      data = await res.json();
+    } catch (err) {
+      errorEl.textContent = 'Network error: ' + err.message;
+      listEl.innerHTML = '';
+      return;
+    }
+    if (data.error) {
+      errorEl.textContent = data.error;
+      if (!data.path) { listEl.innerHTML = ''; return; }
+    }
+
+    currentPath = data.path;
+    currentEl.innerHTML = '';
+    const pathSpan = document.createElement('span');
+    pathSpan.textContent = data.path;
+    currentEl.appendChild(pathSpan);
+    if (data.has_tls_here) {
+      const b = document.createElement('span');
+      b.className = 'badge';
+      b.textContent = 'contains _tls.h5';
+      currentEl.appendChild(b);
+    }
+
+    // Breadcrumb
+    breadcrumb.innerHTML = '';
+    (data.breadcrumbs || []).forEach((bc, i, arr) => {
+      const a = document.createElement('a');
+      a.textContent = bc.name || '/';
+      a.title = bc.path;
+      a.onclick = () => loadDirs(bc.path);
+      breadcrumb.appendChild(a);
+      if (i < arr.length - 1) {
+        const sep = document.createElement('span');
+        sep.className = 'sep';
+        sep.textContent = ' › ';
+        breadcrumb.appendChild(sep);
+      }
+    });
+    if (data.parent) {
+      const up = document.createElement('button');
+      up.type = 'button';
+      up.className = 'btn btn-outline btn-sm';
+      up.style.marginLeft = '8px';
+      up.textContent = '↑ Up';
+      up.onclick = () => loadDirs(data.parent);
+      breadcrumb.appendChild(up);
+    }
+
+    // Entries
+    listEl.innerHTML = '';
+    if (!data.entries || data.entries.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'modal-empty';
+      empty.textContent = 'No subdirectories here.';
+      listEl.appendChild(empty);
+      return;
+    }
+    data.entries.forEach(e => {
+      const row = document.createElement('div');
+      row.className = 'dir-row' + (e.has_tls ? ' has-tls' : '');
+      row.title = e.path;
+      const icon = document.createElement('span');
+      icon.className = 'icon';
+      icon.textContent = '\u{1F4C1}'; // folder
+      const name = document.createElement('span');
+      name.className = 'name';
+      name.textContent = e.name;
+      row.appendChild(icon);
+      row.appendChild(name);
+      if (e.has_tls) {
+        const badge = document.createElement('span');
+        badge.className = 'tls-badge';
+        badge.textContent = 'tls';
+        row.appendChild(badge);
+      }
+      const chev = document.createElement('span');
+      chev.className = 'chev';
+      chev.textContent = '›';
+      row.appendChild(chev);
+      row.onclick = () => loadDirs(e.path);
+      listEl.appendChild(row);
+    });
+  }
+
+  function open() {
+    modal.classList.add('open');
+    loadDirs((dirInputEl && dirInputEl.value.trim()) || '');
+  }
+  function close() { modal.classList.remove('open'); }
+
+  browseBtn.addEventListener('click', open);
+  closeBtn.addEventListener('click', close);
+  cancelBtn.addEventListener('click', close);
+  selectBtn.addEventListener('click', () => {
+    if (!currentPath || !dirInputEl) return;
+    selectBtn.disabled = true;
+    selectBtn.textContent = 'Loading…';
+    dirInputEl.value = currentPath;
+    if (dirFormEl) dirFormEl.requestSubmit();
+    // Close happens implicitly once the new page loads; explicit close
+    // here would hide the disabled state too early.
+  });
+  modal.addEventListener('click', (e) => { if (e.target === modal) close(); });
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && modal.classList.contains('open')) close();
+  });
+})();
+</script>
+</body>
+</html>

--- a/quicklook/app/templates/tls_summary.html
+++ b/quicklook/app/templates/tls_summary.html
@@ -85,6 +85,37 @@
     thead th.sort-desc .arrow::before { content: "\25BC"; opacity: 1; color: var(--primary); }
     thead th .arrow::before { content: "\25C7"; }
 
+    /* Per-column filter row — distinct class (`.col-filter-row`) to avoid
+       colliding with the modal's `.filter-row` (flex layout). Padding
+       matches the header (12px) and body (12px) cells so each input sits
+       flush under its column header. */
+    thead tr.col-filter-row th {
+      cursor: default; padding: 4px 12px; background: var(--card-bg);
+      text-transform: none; letter-spacing: normal; font-weight: normal;
+      vertical-align: middle;
+    }
+    thead tr.col-filter-row th:hover { background: var(--card-bg); }
+    .col-filter-row input {
+      width: 100%; min-width: 0; box-sizing: border-box;
+      padding: 4px 6px; border: 1px solid var(--input-border); border-radius: 4px;
+      font-size: 0.75rem; background: var(--input-bg); color: var(--text);
+      font-family: inherit; margin: 0;
+    }
+    .col-filter-row input:focus { outline: none; border-color: var(--primary); }
+    .col-filter-row input.has-value {
+      border-color: var(--primary); background: var(--hover-bg); font-weight: 600;
+    }
+    .filter-hint {
+      font-size: 0.75rem; color: var(--text-sec);
+      margin: 0 0 6px 4px;
+    }
+    .filter-hint code {
+      background: var(--input-bg); border: 1px solid var(--border-light);
+      border-radius: 3px; padding: 0 4px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.72rem;
+    }
+
     tbody td {
       padding: 8px 12px; border-bottom: 1px solid var(--border-light);
       vertical-align: middle; white-space: nowrap;
@@ -305,6 +336,10 @@
 
 <h1>TLS Results Summary</h1>
 <p class="subtitle">All saved TLS HDF5 outputs &mdash; click a column to sort, type to filter.</p>
+<p class="filter-hint">
+  Per-column filter syntax: <code>&gt;5</code>, <code>&lt;10</code>, <code>&gt;=2</code>, <code>&lt;=1</code>, <code>=5</code>, <code>3..7</code> (range) for numbers;
+  <code>==exact</code> for full match, else substring for text.
+</p>
 
 {% if rows %}
 <div class="table-wrap">
@@ -329,6 +364,26 @@
         <th data-key="toi" data-type="num">TOI <span class="arrow"></span></th>
         <th data-key="tic" data-type="num">TIC <span class="arrow"></span></th>
         <th>Files</th>
+      </tr>
+      <tr class="col-filter-row">
+        <th><input type="text" data-col="0"  data-type="str" placeholder="text"></th>
+        <th><input type="text" data-col="1"  data-type="str" placeholder="text"></th>
+        <th><input type="text" data-col="2"  data-type="num" placeholder="> < .."></th>
+        <th><input type="text" data-col="3"  data-type="num" placeholder="> < .."></th>
+        <th><input type="text" data-col="4"  data-type="num" placeholder="> < .."></th>
+        <th><input type="text" data-col="5"  data-type="num" placeholder="> < .."></th>
+        <th><input type="text" data-col="6"  data-type="num" placeholder="> < .."></th>
+        <th><input type="text" data-col="7"  data-type="num" placeholder="> < .."></th>
+        <th><input type="text" data-col="8"  data-type="num" placeholder="> < .."></th>
+        <th><input type="text" data-col="9"  data-type="num" placeholder="> < .."></th>
+        <th><input type="text" data-col="10" data-type="num" placeholder="> < .."></th>
+        <th><input type="text" data-col="11" data-type="num" placeholder="> < .."></th>
+        <th><input type="text" data-col="12" data-type="num" placeholder="> < .."></th>
+        <th><input type="text" data-col="13" data-type="num" placeholder="> < .."></th>
+        <th><input type="text" data-col="14" data-type="num" placeholder="> < .."></th>
+        <th><input type="text" data-col="15" data-type="num" placeholder="> < .."></th>
+        <th><input type="text" data-col="16" data-type="num" placeholder="> < .."></th>
+        <th></th>
       </tr>
     </thead>
     <tbody>
@@ -525,19 +580,87 @@ const search = document.getElementById('search');
 const countEl = document.getElementById('count');
 const rows = table ? Array.from(table.tBodies[0].rows) : [];
 
-function applySearch() {
+/* Parse a per-column filter expression into a predicate.
+   Numeric: >n, <n, >=n, <=n, =n / ==n, a..b ; bare text → substring on cell.
+   String:  ==text → exact (case-insensitive) ; else substring. */
+const NUM_RE = '-?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?';
+function parseFilterExpr(expr, type) {
+  expr = (expr || '').trim();
+  if (!expr) return null;
+  if (type === 'num') {
+    let m;
+    m = expr.match(new RegExp('^>=\\s*(' + NUM_RE + ')$'));
+    if (m) { const n = parseFloat(m[1]); return (v) => !isNaN(v) && v >= n; }
+    m = expr.match(new RegExp('^<=\\s*(' + NUM_RE + ')$'));
+    if (m) { const n = parseFloat(m[1]); return (v) => !isNaN(v) && v <= n; }
+    m = expr.match(new RegExp('^>\\s*(' + NUM_RE + ')$'));
+    if (m) { const n = parseFloat(m[1]); return (v) => !isNaN(v) && v > n; }
+    m = expr.match(new RegExp('^<\\s*(' + NUM_RE + ')$'));
+    if (m) { const n = parseFloat(m[1]); return (v) => !isNaN(v) && v < n; }
+    m = expr.match(new RegExp('^==?\\s*(' + NUM_RE + ')$'));
+    if (m) {
+      const n = parseFloat(m[1]);
+      return (v) => !isNaN(v) && Math.abs(v - n) <= 1e-9 * Math.max(1, Math.abs(n));
+    }
+    m = expr.match(new RegExp('^(' + NUM_RE + ')\\s*\\.\\.\\s*(' + NUM_RE + ')$'));
+    if (m) {
+      const a = parseFloat(m[1]), b = parseFloat(m[2]);
+      return (v) => !isNaN(v) && v >= Math.min(a, b) && v <= Math.max(a, b);
+    }
+    // Fallback for numeric column: substring on displayed text.
+    const needle = expr.toLowerCase();
+    return (v, text) => text.includes(needle);
+  }
+  // String
+  const exact = expr.match(/^==?\s*(.+)$/);
+  if (exact) {
+    const target = exact[1].trim().toLowerCase();
+    return (_v, text) => text === target;
+  }
+  const needle = expr.toLowerCase();
+  return (_v, text) => text.includes(needle);
+}
+
+const filterInputs = document.querySelectorAll('.col-filter-row input');
+
+function applyFilters() {
   if (!table) return;
-  const q = search.value.trim().toLowerCase();
+  const q = (search ? search.value : '').trim().toLowerCase();
+
+  // Build active per-column predicates.
+  const active = [];
+  filterInputs.forEach((inp) => {
+    const expr = inp.value.trim();
+    inp.classList.toggle('has-value', expr !== '');
+    if (!expr) return;
+    const colIdx = parseInt(inp.dataset.col, 10);
+    const type = inp.dataset.type || 'str';
+    const pred = parseFilterExpr(expr, type);
+    if (pred) active.push({ colIdx, type, pred });
+  });
+
   let visible = 0;
   for (const row of rows) {
-    const text = row.textContent.toLowerCase();
-    const match = q === '' || text.includes(q);
-    row.style.display = match ? '' : 'none';
-    if (match) visible++;
+    let show = q === '' || row.textContent.toLowerCase().includes(q);
+    if (show) {
+      for (const { colIdx, type, pred } of active) {
+        const td = row.cells[colIdx];
+        if (!td) { show = false; break; }
+        const text = td.textContent.trim().toLowerCase();
+        const raw = (type === 'num')
+          ? parseFloat(td.dataset.v !== undefined && td.dataset.v !== '' ? td.dataset.v : td.textContent)
+          : text;
+        if (!pred(raw, text)) { show = false; break; }
+      }
+    }
+    row.style.display = show ? '' : 'none';
+    if (show) visible++;
   }
   countEl.textContent = visible + ' / ' + rows.length + ' results';
 }
-if (search) search.addEventListener('input', applySearch);
+
+if (search) search.addEventListener('input', applyFilters);
+filterInputs.forEach(inp => inp.addEventListener('input', applyFilters));
 
 /* Sort by column (toggle asc/desc, numeric vs string aware) */
 let activeTh = null;

--- a/quicklook/plot.py
+++ b/quicklook/plot.py
@@ -55,6 +55,41 @@ def use_style(name="science"):
         pl.style.use(str(style_path))
 
 
+def _strip_for_bin(lc):
+    """Drop non-numeric extra columns before calling LightCurve.bin().
+
+    LightCurve.bin() delegates to astropy.timeseries.aggregate_downsample(),
+    which sums every column. HLSP products such as QLP, TGLC, CDIPS, and
+    pathos carry string-typed columns (e.g. "quality" tags, sector strings)
+    that crash with::
+
+        the resolved dtypes are not compatible with add.reduce.
+
+    Stripping non-numeric extras keeps time/flux/flux_err and any numeric
+    extras (cadenceno, etc.), so binning produces real even/odd panels
+    instead of silently failing.
+    """
+    drop = []
+    for col in list(lc.colnames):
+        if col in ("time", "flux", "flux_err"):
+            continue
+        dtype = getattr(lc[col], "dtype", None)
+        if dtype is None:
+            # e.g. astropy Time/Quantity-like columns without a plain dtype;
+            # aggregate_downsample cannot reduce them, so drop them.
+            drop.append(col)
+            continue
+        try:
+            is_numeric = np.issubdtype(dtype, np.number)
+        except TypeError:
+            is_numeric = False
+        if not is_numeric:
+            drop.append(col)
+    if drop:
+        lc.remove_columns(drop)
+    return lc
+
+
 def plot_odd_even_transit(fold_lc, tls_results, bin_mins=10, markersize=6, ax=None):
     if ax is None:
         _, ax = pl.subplots()
@@ -70,8 +105,10 @@ def plot_odd_even_transit(fold_lc, tls_results, bin_mins=10, markersize=6, ax=No
     # Force writeable deep copies; stacked boolean slices on the folded
     # LightCurve leave the underlying flux/time buffers non-writeable, which
     # breaks the in-place ufuncs used by LightCurve.bin() under numpy >= 2.0.
-    even_lc = clipped_lc[clipped_lc.even_mask].copy()
-    odd_lc = clipped_lc[clipped_lc.odd_mask].copy()
+    # Strip non-numeric extra columns so aggregate_downsample doesn't choke
+    # on string-typed columns carried by HLSP pipelines (QLP, TGLC, CDIPS).
+    even_lc = _strip_for_bin(clipped_lc[clipped_lc.even_mask].copy())
+    odd_lc = _strip_for_bin(clipped_lc[clipped_lc.odd_mask].copy())
 
     if len(even_lc) > 0:
         try:
@@ -85,7 +122,7 @@ def plot_odd_even_transit(fold_lc, tls_results, bin_mins=10, markersize=6, ax=No
                 zorder=2,
             )
         except (ValueError, TypeError) as e:
-            logger.debug(f"Could not bin even-transit data: {e}")
+            logger.warning(f"Could not bin even-transit data: {e}")
     if len(odd_lc) > 0:
         try:
             odd_lc.bin(time_bin_size=bin_mins * u.minute).errorbar(
@@ -98,7 +135,7 @@ def plot_odd_even_transit(fold_lc, tls_results, bin_mins=10, markersize=6, ax=No
                 zorder=2,
             )
         except (ValueError, TypeError) as e:
-            logger.debug(f"Could not bin odd-transit data: {e}")
+            logger.warning(f"Could not bin odd-transit data: {e}")
 
     ax.plot(
         (tls_results.model_folded_phase - 0.5) * tls_results.period,
@@ -155,7 +192,7 @@ def plot_secondary_eclipse(flat_lc, tls_results, tmask, bin_mins=10, markersize=
     ax.axvline(half_phase + t14 / 2, 0, 1, label="__nolegend__", c="k", ls="--")
     try:
         if len(clipped_lc2) > 0:
-            clipped_lc2.bin(time_bin_size=bin_mins * u.minute).errorbar(
+            _strip_for_bin(clipped_lc2).bin(time_bin_size=bin_mins * u.minute).errorbar(
                 ax=ax,
                 marker="o",
                 markersize=markersize,
@@ -164,7 +201,7 @@ def plot_secondary_eclipse(flat_lc, tls_results, tmask, bin_mins=10, markersize=
                 zorder=2,
             )
     except (ValueError, TypeError) as e:
-        logger.debug(f"Could not bin secondary eclipse data: {e}")
+        logger.warning(f"Could not bin secondary eclipse data: {e}")
     ax.set_xlabel("Orbital Phase")
     ax.set_xlim(phase_lo, phase_hi)
     ax.legend()

--- a/quicklook/tql.py
+++ b/quicklook/tql.py
@@ -1062,10 +1062,10 @@ class TessQuickLook:
         None
         """
         # Append meta
-        # self.tls_results["meta"] = self.raw_lc._meta
-        # self.tls_results["pipeline"] = self.pipeline
-        # self.tls_results["flux_type"] = self.flux_type
-        # self.tls_results["exptime"] = self.exptime
+        self.tls_results["pipeline"] = self.pipeline
+        self.tls_results["flux_type"] = self.flux_type
+        self.tls_results["exptime"] = self.exptime
+        self.tls_results["cadence"] = self.cadence
 
         # Append the raw light curve
         self.tls_results["time_raw"] = self.raw_lc.time.value


### PR DESCRIPTION
Plot / pipeline fixes
- quicklook/plot.py: restore missing odd-even and secondary-eclipse
  panels. New _strip_for_bin() helper drops non-numeric extra columns
  before LightCurve.bin(), so aggregate_downsample no longer chokes on
  string-typed quality columns carried by QLP / TGLC / CDIPS HLSPs.
  Also guards astropy Time-typed columns whose .dtype access raises
  AttributeError. Each .bin().errorbar() is now wrapped in
  try/except (ValueError, TypeError) with logger.warning so any future
  failure surfaces in the per-target log instead of producing a
  silently empty panel.
- quicklook/tql.py: in append_tls_results, persist pipeline, flux_type,
  exptime, and cadence into the TLS h5 (previously commented out, which
  is why every column for these fields was empty in summaries).

TLS Summary page (new)
- New template quicklook/app/templates/tls_summary.html and new Flask
  view tls_summary in quicklook/app/app.py. Sortable + searchable table
  of every *_tls.h5 result. Columns: Target, Pipeline, Exp (s), Sector,
  Porb [d], Dur [hr], Rp/Rs, Depth [ppt], SDE, SNR, FAP, Odd-even delta,
  N_tr, Prot [d], GLS power, TOI, TIC, Files. Click any header to sort
  (numeric vs string aware, missing values to the bottom, numerics
  default to descending). Live filter input across all columns with a
  visible / total counter. Light + dark themes.
- New helper _coerce_scalar() unwraps 0-d / 1-elem numpy arrays into
  Python scalars so Jinja sees real values.
- New helper _parse_tls_filename() recovers pipeline, flux_type, and
  cadence from the filename for older h5 files saved before the tql.py
  fix above. Falls back to a sensible exptime hint for SPOC short
  cadence.
- Files that fail to parse are surfaced under a collapsible "skipped"
  details block, not silently dropped.

Directory picker for the TLS Summary page
- tls_summary accepts ?dir=<absolute_path>. Default (reads
  app/static/outputs/) is preserved. Path is validated; bad / missing
  paths fall back to the default and surface a dir_error banner.
- Files outside OUTPUT_DIR show their absolute on-disk path in the
  Files column instead of broken /static/outputs/... links. No
  generic file-streaming endpoint is added.
- Header form offers a path input with Load, a Reset link (only when
  on a custom dir), and a Browse... button.
- New Flask route list_dirs (/list-dirs?path=...) returns immediate
  subdirectory listings as JSON with a has_tls flag per entry. Scoped
  to allowed roots via _get_allowed_browse_roots() (default: \$HOME;
  override with colon-separated ALLOWED_BROWSE_ROOTS env var) and
  _is_under_allowed_root(). Anything outside returns 403 with no info
  leak. Skips hidden directories; reports has_tls_here for the current
  path; provides breadcrumbs and a parent path for navigation.
- Browse modal: clickable breadcrumb + Up button; folder rows with a
  "tls" pill on dirs that contain *_tls.h5; "Only show folders with
  TLS files" checkbox (persisted in localStorage) that hides non-TLS
  rows via CSS; ESC / backdrop / x / Cancel close the modal.
- Recent-dir history persisted in localStorage
  (tls-summary-dir-history, last 10). Selected directory itself is
  persisted (tls-summary-current-dir) so bare visits to /tls-summary
  redirect once to ?dir=<saved>; Reset link clears it.

Improved error visibility
- quicklook/app/app.py: the broad except Exception around job runs
  now captures traceback.format_exc() into the per-target log so
  "failed unexpectedly" entries include the offending file:line. The
  GUI badge still shows only the short str(e).

Gallery / index polish
- gallery.html: added "Summary" button in the top bar linking to
  /tls-summary; added "per page" dropdown (12 / 24 / 48 / 96 / 192)
  beside Next. Pagination links propagate the value; changing the
  dropdown reloads with the new size and resets to page 1. Server-
  side allowlist (GALLERY_PER_PAGE_CHOICES) validates ?per_page=.
  Fixed CSS so the "per page" label text no longer inherits the
  .pagination span button pill style.
- index.html: added a "TLS Summary" entry to the footer-nav.

Unified loading overlay
- Same .page-loading markup + .pl-spinner CSS on index.html,
  gallery.html, and tls_summary.html. Shown when the user clicks
  TLS Summary (index + gallery) or changes the selected directory /
  clicks Reset (tls_summary). Lazy lookup of #pageLoading inside the
  click handler so the script-runs-before-element ordering pitfall
  cannot prevent the overlay from showing.